### PR TITLE
make HTTP status code available to error handlers

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSourceService.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceService.cs
@@ -188,7 +188,7 @@ namespace LaunchDarkly.EventSource
             if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
             {
 
-                throw new EventSourceServiceCancelledException(Resources.EventSource_204_Response);
+                throw new EventSourceServiceUnsuccessfulResponseException(Resources.EventSource_204_Response, (int)response.StatusCode);
             }
 
             if (response.Content == null)
@@ -210,7 +210,8 @@ namespace LaunchDarkly.EventSource
         {
             if (response.IsSuccessStatusCode == false)
             {
-                throw new EventSourceServiceCancelledException(string.Format(Resources.EventSource_HttpResponse_Not_Successful, (int)response.StatusCode));
+                throw new EventSourceServiceUnsuccessfulResponseException(string.Format(Resources.EventSource_HttpResponse_Not_Successful, (int)response.StatusCode),
+                    (int)response.StatusCode);
             }
         }
 

--- a/src/LaunchDarkly.EventSource/EventSourceServiceCancelledException.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceServiceCancelledException.cs
@@ -4,7 +4,11 @@ using System.Text;
 
 namespace LaunchDarkly.EventSource
 {
-    internal class EventSourceServiceCancelledException : Exception
+    /// <summary>
+    /// General superclass for exceptions that caused the EventSource to disconnect or fail to establish
+    /// a connection.
+    /// </summary>
+    public class EventSourceServiceCancelledException : Exception
     {
 
         #region Public Constructors 

--- a/src/LaunchDarkly.EventSource/EventSourceServiceUnsuccessfulResponseException.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceServiceUnsuccessfulResponseException.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace LaunchDarkly.EventSource
+{
+    internal class EventSourceServiceUnsuccessfulResponseException : EventSourceServiceCancelledException
+    {
+        #region Public Properties
+
+        public int StatusCode
+        {
+            get;
+            private set;
+        }
+
+        #endregion
+
+        #region Public Constructors 
+
+        public EventSourceServiceUnsuccessfulResponseException(string message, int statusCode) : base(message)
+        {
+            StatusCode = statusCode;
+        }
+
+        #endregion
+
+    }
+}

--- a/src/LaunchDarkly.EventSource/EventSourceServiceUnsuccessfulResponseException.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceServiceUnsuccessfulResponseException.cs
@@ -2,7 +2,11 @@ using System;
 
 namespace LaunchDarkly.EventSource
 {
-    internal class EventSourceServiceUnsuccessfulResponseException : EventSourceServiceCancelledException
+    /// <summary>
+    /// Indicates that the EventSource was able to establish an HTTP connection, but received a
+    /// non-successful status code.
+    /// </summary>
+    public class EventSourceServiceUnsuccessfulResponseException : EventSourceServiceCancelledException
     {
         #region Public Properties
 

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
@@ -285,7 +285,7 @@ namespace LaunchDarkly.EventSource.Tests
         }
 
         [Fact]
-        public async Task Given_content_type_not_equal_to_eventstream_when_the_http_response_is_recieved_then_error_event_should_occur()
+        public async Task Given_content_type_not_equal_to_eventstream_when_the_http_response_is_received_then_error_event_should_occur()
         {
             // Arrange
             var handler = new StubMessageHandler();
@@ -318,7 +318,7 @@ namespace LaunchDarkly.EventSource.Tests
         }
 
         [Fact]
-        public async Task Given_204_when_the_http_response_is_recieved_then_error_event_should_occur()
+        public async Task Given_204_when_the_http_response_is_received_then_error_event_should_occur()
         {
             // Arrange
             var handler = new StubMessageHandler();
@@ -347,7 +347,7 @@ namespace LaunchDarkly.EventSource.Tests
         [InlineData(HttpStatusCode.BadRequest)]
         [InlineData(HttpStatusCode.RequestTimeout)]
         [InlineData(HttpStatusCode.Unauthorized)]
-        public async Task Given_status_code_when_the_http_response_is_recieved_then_error_event_should_occur(HttpStatusCode statusCode)
+        public async Task Given_status_code_when_the_http_response_is_received_then_error_event_should_occur(HttpStatusCode statusCode)
         {
             // Arrange
             var handler = new StubMessageHandler();


### PR DESCRIPTION
This is necessary in order to implement the desired "stop trying to do things if we get a 401 error" logic in the client. Previously, the information we passed to EventSource error handlers only contained a string description of the error; this adds an exception subclass that contains the status code.