### PR TITLE
when there's a backoff delay, actually do the delay

### DIFF
--- a/console-app-dotnetcore/Program.cs
+++ b/console-app-dotnetcore/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading;
 using LaunchDarkly.EventSource;
+using Common.Logging;
+using Common.Logging.Simple;
 
 namespace EventSource_ConsoleApp_DotNetCore
 {
@@ -10,6 +12,8 @@ namespace EventSource_ConsoleApp_DotNetCore
 
         static void Main(string[] args)
         {
+            LogManager.Adapter = new Common.Logging.Simple.DebugLoggerFactoryAdapter();
+
             Log("Starting...");
 
             var url = "<Insert API URL Here>";

--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -117,7 +117,7 @@ namespace LaunchDarkly.EventSource
             var cancellationToken = _pendingRequest.Token;
             while (!cancellationToken.IsCancellationRequested)
             {
-                MaybeWaitWithBackOff();
+                await MaybeWaitWithBackOff();
                 try
                 {
                     await ConnectToEventSourceAsync(cancellationToken);
@@ -131,7 +131,7 @@ namespace LaunchDarkly.EventSource
             }
         }
 
-        private async void MaybeWaitWithBackOff()  {
+        private async Task MaybeWaitWithBackOff()  {
             if (_backOff.GetReconnectAttemptCount() > 0 && _retryDelay > TimeSpan.FromMilliseconds(0))
             {
                 TimeSpan sleepTime = _backOff.GetNextBackOff();


### PR DESCRIPTION
https://app.clubhouse.io/launchdarkly/story/21565/net-sdk-does-not-wait-before-reconnecting-to-stream

I tested this by running the test console app in this repo against a local streamer, then killing the streamer. Prior to this fix, it would log messages of "reconnecting after ____ milliseconds" but the next reconnect attempt would happen immediately.