### PR TITLE
don't share the same reconnect counter across all streams

### DIFF
--- a/src/LaunchDarkly.EventSource/ExponentialBackoffWithDecorrelation.cs
+++ b/src/LaunchDarkly.EventSource/ExponentialBackoffWithDecorrelation.cs
@@ -9,7 +9,7 @@ namespace LaunchDarkly.EventSource
         private readonly TimeSpan _minimumDelay;
         private readonly TimeSpan _maximumDelay;
         private readonly Random _jitterer = new Random();
-        private static int _reconnectAttempts;
+        private int _reconnectAttempts;
 
         public ExponentialBackoffWithDecorrelation(TimeSpan minimumDelay, TimeSpan maximumDelay)
         {


### PR DESCRIPTION
See [ch21070](https://app.clubhouse.io/launchdarkly/story/21070/net-xamarin-opening-a-brand-new-stream-causes-reconnecting-log-messages) for more details.