### PR TITLE
fix stream reconnect logic

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSourceService.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceService.cs
@@ -63,7 +63,6 @@ namespace LaunchDarkly.EventSource
             cancellationToken.ThrowIfCancellationRequested();
 
             await ConnectToEventSourceApi(processResponse, cancellationToken);
-
         }
 
         #endregion

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
@@ -354,6 +354,7 @@ namespace LaunchDarkly.EventSource.Tests
             var evt = new EventSource(config);
 
             var receiver = new ErrorReceiver(evt);
+            receiver.CloseEventSourceOnError = true;
 
             //// Act
             await evt.StartAsync();
@@ -375,6 +376,7 @@ namespace LaunchDarkly.EventSource.Tests
             var evt = new EventSource(new Configuration(_uri, handler));
 
             var receiver = new ErrorReceiver(evt);
+            receiver.CloseEventSourceOnError = true;
 
             //Act
             await evt.StartAsync();
@@ -402,6 +404,7 @@ namespace LaunchDarkly.EventSource.Tests
             var evt = new EventSource(new Configuration(_uri, handler));
 
             ErrorReceiver receiver = new ErrorReceiver(evt);
+            receiver.CloseEventSourceOnError = true;
 
             await evt.StartAsync();
 
@@ -469,6 +472,7 @@ namespace LaunchDarkly.EventSource.Tests
             var evt = new StubEventSource(new Configuration(_uri, handler, readTimeout: readTimeout), (int)timeout.TotalMilliseconds);
 
             var receiver = new ErrorReceiver(evt);
+            receiver.CloseEventSourceOnError = true;
 
             await evt.StartAsync();
 
@@ -519,8 +523,7 @@ namespace LaunchDarkly.EventSource.Tests
 
             var evt = new EventSource(new Configuration(_uri, handler));
 
-            ErrorReceiver receiver = new ErrorReceiver(evt);
-            receiver.CloseEventSourceOnError = false;
+            var receiver = new ErrorReceiver(evt);
 
             string messageReceived = null;
             evt.MessageReceived += (_, e) =>
@@ -547,6 +550,7 @@ namespace LaunchDarkly.EventSource.Tests
             var evt = new EventSource(new Configuration(_uri, handler));
 
             var receiver = new ErrorReceiver(evt);
+            receiver.CloseEventSourceOnError = true;
 
             await evt.StartAsync();
 
@@ -556,7 +560,7 @@ namespace LaunchDarkly.EventSource.Tests
 
     class ErrorReceiver
     {
-        public bool CloseEventSourceOnError = true;
+        public bool CloseEventSourceOnError = false;
         public Exception ErrorReceived = null;
         public ReadyState SourceStateReceived;
         private readonly EventSource _source;

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
@@ -353,18 +353,15 @@ namespace LaunchDarkly.EventSource.Tests
 
             var evt = new EventSource(config);
 
-            var wasErrorEventRaised = false;
-            evt.Error += (s, e) =>
-            {
-                wasErrorEventRaised = true;
-            };
+            var receiver = new ErrorReceiver(evt);
 
             //// Act
             await evt.StartAsync();
 
             //// Assert
-            Assert.True(wasErrorEventRaised);
-            Assert.True(evt.ReadyState == ReadyState.Closed);
+            Assert.NotNull(receiver.ErrorReceived);
+            Assert.Equal(ReadyState.Closed, receiver.SourceStateReceived);
+            Assert.Equal(ReadyState.Shutdown, evt.ReadyState);
         }
 
         [Fact]
@@ -377,20 +374,18 @@ namespace LaunchDarkly.EventSource.Tests
 
             var evt = new EventSource(new Configuration(_uri, handler));
 
+            var receiver = new ErrorReceiver(evt);
+
             //Act
-            var raisedEvent = await Assert.RaisesAsync<ExceptionEventArgs>(
-                h => evt.Error += h,
-                h => evt.Error -= h,
-                () => evt.StartAsync());
+            await evt.StartAsync();
 
             //// Assert
-            Assert.NotNull(raisedEvent);
-            Assert.Equal(evt, raisedEvent.Sender);
-            Assert.IsType<EventSourceServiceUnsuccessfulResponseException>(raisedEvent.Arguments.Exception);
-            Assert.Equal(204, ((EventSourceServiceUnsuccessfulResponseException)raisedEvent.Arguments.Exception).StatusCode);
-            Assert.True(evt.ReadyState == ReadyState.Closed);
+            Assert.NotNull(receiver.ErrorReceived);
+            var ex = Assert.IsType<EventSourceServiceUnsuccessfulResponseException>(receiver.ErrorReceived);
+            Assert.Equal(204, ex.StatusCode);
+            Assert.Equal(ReadyState.Closed, receiver.SourceStateReceived);
+            Assert.Equal(ReadyState.Shutdown, evt.ReadyState);
         }
-
 
         [Theory]
         [InlineData(HttpStatusCode.InternalServerError)]
@@ -406,18 +401,16 @@ namespace LaunchDarkly.EventSource.Tests
 
             var evt = new EventSource(new Configuration(_uri, handler));
 
-            //Act
-            var raisedEvent = await Assert.RaisesAsync<ExceptionEventArgs>(
-                h => evt.Error += h,
-                h => evt.Error -= h,
-                () => evt.StartAsync());
+            ErrorReceiver receiver = new ErrorReceiver(evt);
+
+            await evt.StartAsync();
 
             //// Assert
-            Assert.NotNull(raisedEvent);
-            Assert.Equal(evt, raisedEvent.Sender);
-            Assert.IsType<EventSourceServiceUnsuccessfulResponseException>(raisedEvent.Arguments.Exception);
-            Assert.Equal((int)statusCode, ((EventSourceServiceUnsuccessfulResponseException)raisedEvent.Arguments.Exception).StatusCode);
-            Assert.True(evt.ReadyState == ReadyState.Closed);
+            Assert.NotNull(receiver.ErrorReceived);
+            var ex = Assert.IsType<EventSourceServiceUnsuccessfulResponseException>(receiver.ErrorReceived);
+            Assert.Equal((int)statusCode, ex.StatusCode);
+            Assert.Equal(ReadyState.Closed, receiver.SourceStateReceived);
+            Assert.Equal(ReadyState.Shutdown, evt.ReadyState);
         }
 
         [Fact]
@@ -426,7 +419,8 @@ namespace LaunchDarkly.EventSource.Tests
             // Arrange
             var handler = new StubMessageHandler();
 
-            for (int i = 0; i < 2; i++)
+            var nAttempts = 2;
+            for (int i = 0; i < nAttempts; i++)
             {
                 var response = new HttpResponseMessageWithError();
 
@@ -436,7 +430,6 @@ namespace LaunchDarkly.EventSource.Tests
                     "text/event-stream");
 
                 handler.QueueResponse(response);
-
             }
 
             handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.NoContent));
@@ -447,6 +440,10 @@ namespace LaunchDarkly.EventSource.Tests
             evt.Error += (_, e) =>
             {
                 backoffs.Add(evt.BackOffDelay);
+                if (backoffs.Count >= nAttempts)
+                {
+                    evt.Close();
+                }
             };
 
             //Act
@@ -454,7 +451,7 @@ namespace LaunchDarkly.EventSource.Tests
 
             //// Assert
             Assert.NotEmpty(backoffs);
-            Assert.True(backoffs.Distinct().Count() == backoffs.Count());
+            Assert.Equal(backoffs.Distinct().Count(), backoffs.Count());
         }
 
 
@@ -471,25 +468,14 @@ namespace LaunchDarkly.EventSource.Tests
 
             var evt = new StubEventSource(new Configuration(_uri, handler, readTimeout: readTimeout), (int)timeout.TotalMilliseconds);
 
-            var exceptionMessage = string.Empty;
+            var receiver = new ErrorReceiver(evt);
 
-            try
-            {
+            await evt.StartAsync();
 
-                evt.Error += (_, e) =>
-                {
-                    exceptionMessage = e.Exception.Message;
-                    evt.Close();
-                };
-
-                await evt.StartAsync();
-
-            }
-            catch (TaskCanceledException) {}
-
-            Assert.Contains(exceptionMessage, Resources.EventSourceService_Read_Timeout);
-            Assert.True(evt.ReadyState == ReadyState.Shutdown);
-
+            Assert.NotNull(receiver.ErrorReceived);
+            Assert.Contains(receiver.ErrorReceived.Message, Resources.EventSourceService_Read_Timeout);
+            Assert.Equal(ReadyState.Closed, receiver.SourceStateReceived);
+            Assert.Equal(ReadyState.Shutdown, evt.ReadyState);
         }
 
         [Fact]
@@ -520,7 +506,36 @@ namespace LaunchDarkly.EventSource.Tests
 
             Assert.Equal("put", eventName);
             Assert.True(wasMessageReceivedEventRaised);
+        }
 
+        [Fact]
+        public async Task When_server_returns_HTTP_error_a_reconnect_attempt_is_made()
+        {
+            var messageData = "hello";
+
+            var handler = new StubMessageHandler();
+            handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.Unauthorized));
+            handler.QueueStringResponse("event: put\ndata: " + messageData + "\n\n");
+
+            var evt = new EventSource(new Configuration(_uri, handler));
+
+            ErrorReceiver receiver = new ErrorReceiver(evt);
+            receiver.CloseEventSourceOnError = false;
+
+            string messageReceived = null;
+            evt.MessageReceived += (_, e) =>
+            {
+                messageReceived = e.Message.Data;
+                evt.Close();
+            };
+
+            await evt.StartAsync();
+
+            Assert.Equal(2, handler.GetRequests().Count());
+            Assert.NotNull(receiver.ErrorReceived);
+            var ex = Assert.IsType<EventSourceServiceUnsuccessfulResponseException>(receiver.ErrorReceived);
+            Assert.Equal((int)HttpStatusCode.Unauthorized, ex.StatusCode);
+            Assert.Equal(messageData, messageReceived);
         }
 
         [Fact]
@@ -531,14 +546,35 @@ namespace LaunchDarkly.EventSource.Tests
 
             var evt = new EventSource(new Configuration(_uri, handler));
 
-            evt.Error += (_, e) =>
-            {
-                evt.Close();
-            };
+            var receiver = new ErrorReceiver(evt);
 
             await evt.StartAsync();
 
             Assert.Equal(1, handler.GetRequests().Count());
+        }
+    }
+
+    class ErrorReceiver
+    {
+        public bool CloseEventSourceOnError = true;
+        public Exception ErrorReceived = null;
+        public ReadyState SourceStateReceived;
+        private readonly EventSource _source;
+        
+        public ErrorReceiver(EventSource source)
+        {
+            _source = source;
+            source.Error += HandleError;
+        }
+
+        public void HandleError(object sender, ExceptionEventArgs e)
+        {
+            ErrorReceived = e.Exception;
+            SourceStateReceived = _source.ReadyState;
+            if (CloseEventSourceOnError)
+            {
+                _source.Close();
+            }
         }
     }
 }


### PR DESCRIPTION
As reported [here](https://github.com/launchdarkly/dotnet-client/issues/88), the stream would not reconnect if it received an HTTP error code from the server. This was due to accidentally reusing the same CancellationToken to mean both "give up on the current HTTP request" and "give up permanently on the whole event source".

We did in fact have some unit tests with a fake HTTP server returning various errors. But the unit tests all relied on the wrong behavior, i.e. they expected the stream to close itself permanently instead of reconnecting. So I've reworked the tests too - I'd particularly appreciate comments on whether you think the tests now have adequate coverage of the various failure modes. (I also tested this manually against a fake stream.)