### PR TITLE
add null guard for stream reader output

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -254,6 +254,12 @@ namespace LaunchDarkly.EventSource
 
         private void ProcessResponseContent(string content)
         {
+            if (content == null)
+            {
+                // StreamReader may emit a null if the stream has been closed; there's nothing to
+                // be done at this level in that case
+                return;
+            }
             if (string.IsNullOrEmpty(content.Trim()))
             {
                 DispatchEvent();


### PR DESCRIPTION
The lack of a null guard here was mentioned in #37... but I'm pretty sure it was also the cause of a much earlier issue, #24, which unfortunately seems to have fallen through the cracks until now.

As for what a null means in this case: I believe the string in question ultimately comes from `System.IO.StreamReader.ReadLine()`, which will return null if the stream has been closed. I think the reason we don't see this every single time a stream connection is lost is that sometimes we will get an I/O error first and abandon the stream before we get here.