### PR TITLE
prevent unobserved exception when read timeout happens

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSourceService.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceService.cs
@@ -127,7 +127,12 @@ namespace LaunchDarkly.EventSource
 
                 if (completedTask == readTimeoutTask)
                 {
+                    Util.SuppressExceptions(readLineTask); // must do this since we're not going to await the task
                     throw new HttpRequestException(Resources.EventSourceService_Read_Timeout);
+                }
+                else
+                {
+                    Util.SuppressExceptions(readTimeoutTask); // this task should never throw an exception, but you never know
                 }
 
                 processResponse(readLineTask.Result);

--- a/src/LaunchDarkly.EventSource/Util.cs
+++ b/src/LaunchDarkly.EventSource/Util.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LaunchDarkly.EventSource
+{
+    internal class Util
+    {
+        /// <summary>
+        /// Adds a continuation to a task so that if the task throws an uncaught exception, the exception
+        /// is not "unobserved" (which can be a fatal error in some versions of .NET). We must do this
+        /// whenever we're going to discard a task without awaiting it, if there's any possibility that
+        /// it could throw an exception.
+        /// </summary>
+        /// <param name="task">a task we are not going to await</param>
+        public static void SuppressExceptions(Task task)
+        {
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    // Simply accessing the Exception property makes this exception observed.
+                    var e = t.Exception;
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
https://app.clubhouse.io/launchdarkly/story/24949/net-sdk-leaks-an-unhandled-exception-in-lambda

This turned out to be easy to reproduce: I just ran our test console app with a short timeout, and set a global event handler the same way I did in the new unit test here. The event always fired after a timeout happened, although the timing was unpredictable (the test makes it predictable by forcing GC).

There may be other places where we have this problem, I'm not sure yet.