### PR TITLE
treat null from StreamReader as end of stream

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSourceService.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceService.cs
@@ -135,7 +135,13 @@ namespace LaunchDarkly.EventSource
                     Util.SuppressExceptions(readTimeoutTask); // this task should never throw an exception, but you never know
                 }
 
-                processResponse(readLineTask.Result);
+                string line = readLineTask.Result;
+                if (line == null)
+                {
+                    // this means the stream is done, i.e. the connection was closed
+                    return;
+                }
+                processResponse(line);
             }
         }
 


### PR DESCRIPTION
This is a correction to the [previous PR](https://github.com/launchdarkly/dotnet-eventsource/pull/38) which fixed a null reference exception, but did not terminate the stream after getting a null, so the stream reader would keep reading nulls in a tight loop.