### PR TITLE
always dispose of CancellationTokenSource; add Dispose() method

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -1,9 +1,6 @@
 ﻿using Common.Logging;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,7 +10,7 @@ namespace LaunchDarkly.EventSource
     /// Provides an EventSource client for consuming Server Sent Events. Additional details on the Server Sent Events spec
     /// can be found at https://html.spec.whatwg.org/multipage/server-sent-events.html
     /// </summary>
-    public class EventSource : IEventSource
+    public class EventSource : IEventSource, IDisposable
     {
 
         #region Private Fields
@@ -179,7 +176,7 @@ namespace LaunchDarkly.EventSource
         }
 
         /// <summary>
-        /// Closes the connection to the EventSource API.
+        /// Closes the connection to the EventSource API. The EventSource cannot be reopened after this.
         /// </summary>
         public void Close()
         {
@@ -187,6 +184,22 @@ namespace LaunchDarkly.EventSource
 
             Close(ReadyState.Shutdown);
             CancelCurrentRequest();
+        }
+
+        /// <summary>
+        /// Equivalent to calling <see cref="Close"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Close();
+            }
         }
 
         #endregion


### PR DESCRIPTION
The [MS documentation](https://docs.microsoft.com/en-us/dotnet/standard/threading/cancellation-in-managed-threads) says that you should always call `Dispose()` explicitly on a `CancellationTokenSource` when you're done with it. I looked into this a bit more and it seems that it's very unlikely that the way we're using this class could leak any unmanaged resources (most sources seem to agree that the potential for a leak is only if you either 1. use `CreateLinkedTokenSource` or 2. set a timeout) but we might as well be unambiguous about it.

Also, I think the fact that `EventSource` is holding onto an `IDisposable` object means that `EventSource` itself should also be `IDisposable`, so I added that.