### PR TITLE
clean up connection/client/error management, add debug logging

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -189,15 +189,23 @@ namespace LaunchDarkly.EventSource
                         {
                             // This exception could either be the result of us explicitly cancelling a request, in which case we don't
                             // need to do anything else, or it could be that the request timed out.
-                            if (!oe.CancellationToken.IsCancellationRequested)
+                            if (oe.CancellationToken.IsCancellationRequested)
+                            {
+                                realException = null;
+                            }
+                            else
                             {
                                 realException = new TimeoutException();
                             }
                         }
-                        _logger.ErrorFormat("Encountered an error connecting to EventSource: {0}", realException, realException.Message);
-                        _logger.Debug("", realException);
 
-                        OnError(new ExceptionEventArgs(realException));
+                        if (realException != null)
+                        {
+                            _logger.ErrorFormat("Encountered an error connecting to EventSource: {0}", realException, realException.Message);
+                            _logger.Debug("", realException);
+
+                            OnError(new ExceptionEventArgs(realException));
+                        }
                     }
                 }
             }

--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -201,9 +201,6 @@ namespace LaunchDarkly.EventSource
 
                         if (realException != null)
                         {
-                            _logger.ErrorFormat("Encountered an error connecting to EventSource: {0}", realException, realException.Message);
-                            _logger.Debug("", realException);
-
                             OnError(new ExceptionEventArgs(realException));
                         }
                     }


### PR DESCRIPTION
This is a step toward a larger reorganization of the EventSource code that I'm hoping will improve both readability and reliability. I noticed while trying to diagnose a connection problem that it was a bit hard to follow how errors and connection state are being managed. See comments for details.

I also added more debug-level logging; I might remove some of this later but right now it's helpful in verifying that the logic is working as intended.