### PR TITLE
Don't create a default HttpMessageHandler, + misc config cleanup

### DIFF
--- a/src/LaunchDarkly.EventSource/Configuration.cs
+++ b/src/LaunchDarkly.EventSource/Configuration.cs
@@ -38,39 +38,26 @@ namespace LaunchDarkly.EventSource
         public Uri Uri { get; }
 
         /// <summary>
-        /// Gets the connection timeout value used when connecting to the EventSource API.
+        /// the connection timeout value used when connecting to the EventSource API.
         /// </summary>
-        /// <value>
-        /// The <see cref="TimeSpan"/> before the connection times out. The default value is 10,000 milliseconds (10 seconds).
-        /// </value>
         public TimeSpan ConnectionTimeout { get; }
 
         [Obsolete("Use ConnectionTimeout.")]
         public TimeSpan ConnectionTimeOut { get { return ConnectionTimeout; } }
 
         /// <summary>
-        /// Gets the duration to wait before attempting to reconnect to the EventSource API.
+        /// The duration to wait before attempting to reconnect to the EventSource API.
         /// </summary>
-        /// <value>
-        /// The amount of time to wait before attempting to reconnect to the EventSource API. The default value is 1,000 milliseconds (1 second).
-        /// The maximum time allowed is 30,000 milliseconds (30 seconds).
-        /// </value>
         public TimeSpan DelayRetryDuration { get; }
 
         /// <summary>
-        /// Gets the amount of time a connection must stay open before the EventSource resets its backoff delay.
-        /// If a connection fails before the threshold has elapsed, the delay before reconnecting will be greater
-        /// than the last delay; if it fails after the threshold, the delay will start over at the initial minimum
-        /// value. This prevents long delays from occurring on connections that are only rarely restarted.
+        /// The amount of time a connection must stay open before the EventSource resets its backoff delay.
         /// </summary>
         public TimeSpan BackoffResetThreshold { get; }
 
         /// <summary>
-        /// Gets the time-out when reading from the EventSource API.
+        /// The timeout when reading from the EventSource API.
         /// </summary>
-        /// <value>
-        /// The <see cref="TimeSpan"/> before reading times out. The default value is 300,000 milliseconds (5 minutes).
-        /// </value>
         public TimeSpan ReadTimeout { get; }
 
         [Obsolete("Use ReadTimeout.")]
@@ -79,46 +66,30 @@ namespace LaunchDarkly.EventSource
         /// <summary>
         /// Gets the last event identifier.
         /// </summary>
-        /// <remarks>
-        /// Setting the LastEventId in the constructor will add an HTTP request header named "Last-Event-ID" when connecting to the EventSource API
-        /// </remarks>
-        /// <value>
-        /// The last event identifier.
-        /// </value>
         public string LastEventId { get; }
 
         /// <summary>
-        /// Gets the <see cref="Common.Logging.ILog"/> used internally in the <see cref="EventSource"/> class.
+        /// A custom logger to be used for all EventSource log output.
         /// </summary>
-        /// <value>
-        /// The ILog to use for internal logging.
-        /// </value>
         public ILog Logger { get; }
 
         /// <summary>
-        /// Gets or sets the request headers used when connecting to the EventSource API.
+        /// The request headers to be sent with each EventSource HTTP request.
         /// </summary>
-        /// <value>
-        /// The request headers.
-        /// </value>
         public IDictionary<string, string> RequestHeaders { get; }
 
         /// <summary>
-        /// Gets the HttpMessageHandler used to call the EventSource API.
+        /// The HttpMessageHandler that will be used for the HTTP client, or null for the default handler.
         /// </summary>
-        /// <value>
-        /// The <see cref="HttpMessageHandler"/>.
-        /// </value>
         public HttpMessageHandler MessageHandler { get; }
 
         /// <summary>
-        /// Gets the HTTP method that will be used when connecting to the EventSource API.
-        /// Defaults to GET if not specified.
+        /// The HTTP method that will be used when connecting to the EventSource API.
         /// </summary>
         public HttpMethod Method { get; }
 
         /// <summary>
-        /// Gets the request body that will be sent when connecting to the EventSource API, if the HTTP method
+        /// A factory for HTTP request body content, if the HTTP method is one that allows a request body.
         /// is one that allows a request body. This is in the form of a factory function because the request
         /// may need to be sent more than once.
         /// </summary>
@@ -188,7 +159,7 @@ namespace LaunchDarkly.EventSource
             }
 
             Uri = uri;
-            MessageHandler = messageHandler ?? new HttpClientHandler();
+            MessageHandler = messageHandler;
             ConnectionTimeout = connectionTimeout ?? DefaultConnectionTimeout;
             DelayRetryDuration = delayRetryDuration ?? DefaultDelayRetryDuration;
             BackoffResetThreshold = backoffResetThreshold ?? DefaultBackoffResetThreshold;
@@ -204,6 +175,11 @@ namespace LaunchDarkly.EventSource
 
         #region Public Methods
 
+        /// <summary>
+        /// Provides a new <see cref="ConfigurationBuilder"/> for constructing a configuration.
+        /// </summary>
+        /// <param name="uri">the EventSource URI</param>
+        /// <returns>a new builder instance</returns>
         public static ConfigurationBuilder Builder(Uri uri)
         {
             return new ConfigurationBuilder(uri);

--- a/src/LaunchDarkly.EventSource/ConfigurationBuilder.cs
+++ b/src/LaunchDarkly.EventSource/ConfigurationBuilder.cs
@@ -51,12 +51,24 @@ namespace LaunchDarkly.EventSource
 
         #region Public Methods
 
+        /// <summary>
+        /// Constructs a <see cref="Configuration"/> instance based on the current builder properies.
+        /// </summary>
+        /// <returns>the configuration</returns>
         public Configuration Build()
         {
             return new Configuration(_uri, _messageHandler, _connectionTimeout, _delayRetryDuration, _readTimeout,
                 _requestHeaders, _lastEventId, _logger, _method, _requestBodyFactory);
         }
-        
+
+        /// <summary>
+        /// Sets the connection timeout value used when connecting to the EventSource API.
+        /// </summary>
+        /// <remarks>
+        /// The default value is <see cref="Configuration.DefaultConnectionTimeout"/>.
+        /// </remarks>
+        /// <param name="connectionTimeout">the timeout</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder ConnectionTimeout(TimeSpan connectionTimeout)
         {
             Configuration.CheckConnectionTimeout(connectionTimeout);
@@ -64,6 +76,18 @@ namespace LaunchDarkly.EventSource
             return this;
         }
 
+        /// <summary>
+        /// Sets the initial amount of time to wait before attempting to reconnect to the EventSource API.
+        /// </summary>
+        /// <remarks>
+        /// If the connection fails more than once, the retry delay will increase from this value using
+        /// a backoff algorithm.
+        /// 
+        /// The default value is <see cref="Configuration.DefaultDelayRetryDuration"/>. The maximum
+        /// allowed value is <see cref="Configuration.MaximumRetryDuration"/>.
+        /// </remarks>
+        /// <param name="delayRetryDuration">the initial retry delay</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder DelayRetryDuration(TimeSpan delayRetryDuration)
         {
             Configuration.CheckDelayRetryDuration(delayRetryDuration);
@@ -71,12 +95,34 @@ namespace LaunchDarkly.EventSource
             return this;
         }
 
+        /// <summary>
+        /// Sets the amount of time a connection must stay open before the EventSource resets its backoff delay.
+        /// </summary>
+        /// <remarks>
+        /// If a connection fails before the threshold has elapsed, the delay before reconnecting will be greater
+        /// than the last delay; if it fails after the threshold, the delay will start over at the initial minimum
+        /// value. This prevents long delays from occurring on connections that are only rarely restarted.
+        /// 
+        /// The default value is <see cref="Configuration.DefaultBackoffResetThreshold"/>.
+        /// </remarks>
+        /// <param name="backoffResetThreshold">the threshold time</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder BackoffResetThreshold(TimeSpan backoffResetThreshold)
         {
             _backoffResetThreshold = backoffResetThreshold;
             return this;
         }
 
+        /// <summary>
+        /// Sets the timeout when reading from the EventSource API.
+        /// </summary>
+        /// <remarks>
+        /// The connection will be automatically dropped and restarted if the server sends no data within
+        /// this interval. This prevents keeping a stale connection that may no longer be working. It is common
+        /// for SSE servers to send a simple comment line (":") as a heartbeat to prevent timeouts.
+        /// 
+        /// The default value is <see cref="Configuration.DefaultReadTimeout"/>.
+        /// </remarks>
         public ConfigurationBuilder ReadTimeout(TimeSpan readTimeout)
         {
             Configuration.CheckReadTimeout(readTimeout);
@@ -84,56 +130,104 @@ namespace LaunchDarkly.EventSource
             return this;
         }
 
+        /// <summary>
+        /// Sets the last event identifier.
+        /// </summary>
+        /// <remarks>
+        /// Setting this value will cause EventSource to add a "Last-Event-ID" header in its HTTP request.
+        /// This normally corresponds to the <see cref="MessageEvent.LastEventId"/> field of a previously
+        /// received event.
+        /// </remarks>
+        /// <param name="lastEventId">the event identifier</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder LastEventId(string lastEventId)
         {
             _lastEventId = lastEventId;
             return this;
         }
 
+        /// <summary>
+        /// Sets a custom logger to be used for all EventSource log output.
+        /// </summary>
+        /// <remarks>
+        /// By default, EventSource will call <see cref="LogManager.GetLogger(Type)"/> to creates its
+        /// own logger.
+        /// </remarks>
+        /// <param name="logger">a logger instance</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder Logger(ILog logger)
         {
             _logger = logger;
             return this;
         }
 
+        /// <summary>
+        /// Sets the request headers to be sent with each EventSource HTTP request.
+        /// </summary>
+        /// <param name="headers">the headers (must not be null)</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder RequestHeaders(IDictionary<string, string> headers)
         {
-            if (headers == null)
-            {
-                throw new ArgumentNullException(nameof(headers));
-            }
-            _requestHeaders = headers;
+            _requestHeaders = headers ?? throw new ArgumentNullException(nameof(headers));
             return this;
         }
         
+        /// <summary>
+        /// Adds a request header to be sent with each EventSource HTTP request.
+        /// </summary>
+        /// <param name="name">the header name</param>
+        /// <param name="value">the header value </param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder RequestHeader(string name, string value)
         {
             _requestHeaders[name] = value;
             return this;
         }
 
+        /// <summary>
+        /// Sets the HttpMessageHandler that will be used for the HTTP client, or null for the default handler.
+        /// </summary>
+        /// <param name="handler">the message handler implementation</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder MessageHandler(HttpMessageHandler handler)
         {
             this._messageHandler = handler;
             return this;
         }
 
+        /// <summary>
+        /// Sets the HTTP method that will be used when connecting to the EventSource API.
+        /// </summary>
+        /// <remarks>
+        /// By default, this is <see cref="HttpMethod.Get"/>.
+        /// </remarks>
         public ConfigurationBuilder Method(HttpMethod method)
         {
-            if (method == null)
-            {
-                throw new ArgumentNullException(nameof(method));
-            }
-            this._method = method;
+            this._method = method ?? throw new ArgumentNullException(nameof(method));
             return this;
         }
 
+        /// <summary>
+        /// Sets a factory for HTTP request body content, if the HTTP method is one that allows a request body.
+        /// </summary>
+        /// <remarks>
+        /// This is in the form of a factory function because the request may need to be sent more than once.
+        /// </remarks>
+        /// <param name="factory">the factory function, or null for none</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder RequestBodyFactory(Configuration.HttpContentFactory factory)
         {
             this._requestBodyFactory = factory;
             return this;
         }
 
+        /// <summary>
+        /// Equivalent <see cref="RequestBodyFactory(Configuration.HttpContentFactory)"/>, but for content
+        /// that is a simple string.
+        /// </summary>
+        /// <param name="bodyString">the content</param>
+        /// <param name="contentType">the Content-Type header</param>
+        /// <returns>the builder</returns>
         public ConfigurationBuilder RequestBody(string bodyString, string contentType)
         {
             return RequestBodyFactory(() => new StringContent(bodyString, Encoding.UTF8, contentType));

--- a/src/LaunchDarkly.EventSource/EventSourceService.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceService.cs
@@ -140,12 +140,7 @@ namespace LaunchDarkly.EventSource
                 processResponse(line);
             }
         }
-
-        private HttpClient GetHttpClient()
-        {
-            return new HttpClient(_configuration.MessageHandler, false) { Timeout = _configuration.ConnectionTimeout };
-        }
-
+        
         private HttpRequestMessage CreateHttpRequestMessage(Uri uri)
         {
             var request = new HttpRequestMessage(_configuration.Method ?? HttpMethod.Get, uri);

--- a/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTests.cs
@@ -179,10 +179,9 @@ namespace LaunchDarkly.EventSource.Tests
         }
 
         [Fact]
-        public void MessageHandlerDefaultsToHttpClientHandler()
+        public void MessageHandlerDefaultsToNull()
         {
-            var b = Configuration.Builder(uri);
-            Assert.IsType<HttpClientHandler>(b.Build().MessageHandler);
+            Assert.Null(Configuration.Builder(uri).Build().MessageHandler);
         }
 
         [Fact]

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceTests.cs
@@ -15,6 +15,14 @@ namespace LaunchDarkly.EventSource.Tests
         private readonly Uri _uri = new Uri("http://test.com");
 
         [Fact]
+        public void Can_Create_and_start_EventSource_without_specifying_message_handler()
+        {
+            // Testing this just because all of the other tests use a StubMessageHandler
+            var evt = new EventSource(Configuration.Builder(_uri).Build());
+            evt.StartAsync();
+        }
+
+        [Fact]
         public async Task When_a_comment_SSE_is_received_then_a_comment_event_is_raised()
         {
             var commentSent = ": hello";


### PR DESCRIPTION
We've been always using the `HttpClient` constructor that can take an `HttpMessageHandler` instance, and if the application didn't specify one then we create one. There's really no reason to do this unless we actually want to override the message handler, and [on some platforms](https://nicksnettravels.builttoroam.com/post-2019-04-24-xamarin-and-the-httpclient-for-ios-android-and-windows-aspx/) it prevents the OS from substituting a better implementation.

I also did some general cleanup of the configuration classes, mostly just doc comments.