### PR TITLE
Set LastEventId header on reconnection

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -293,6 +293,7 @@ namespace LaunchDarkly.EventSource
 
             await svc.GetDataAsync(
                 ProcessResponseContent,
+                _lastEventId,
                 cancellationToken
             );
         }

--- a/test/LaunchDarkly.EventSource.Tests/Stubs/StubHandler.cs
+++ b/test/LaunchDarkly.EventSource.Tests/Stubs/StubHandler.cs
@@ -127,6 +127,7 @@ namespace LaunchDarkly.EventSource.Tests
                     }
                     if (action.ShouldQuit())
                     {
+                        output.Close();
                         return;
                     }
                     byte[] data = Encoding.UTF8.GetBytes(action.Content);


### PR DESCRIPTION
This patch fixes a problem that arises when disconnecting and then reconnecting.
If the `last-event-id` header is not set, the server can send old events. By setting the header to the the last event id seen, we ensure we always receive up-to-date events.