### PR TITLE
enable users to run tests locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
           name: install packages
           command: apt-get -q update && apt-get install -qy awscli
       - checkout
-      - run: aws s3 cp s3://launchdarkly-pastebin/ci/dotnet/LaunchDarkly.EventSource.snk LaunchDarkly.EventSource.snk
       - run: dotnet restore
       - run: dotnet build src/LaunchDarkly.EventSource -f netstandard1.4
       - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f netcoreapp2.0

--- a/src/LaunchDarkly.EventSource/Properties/AssemblyInfo.cs
+++ b/src/LaunchDarkly.EventSource/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System.Runtime.CompilerServices;
 
 // Added to allow the Test Project to access internal types and methods.
-[assembly: InternalsVisibleTo("LaunchDarkly.EventSource.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010015ba095c5a95acefa557867cec3f488906ec0ef6fe6728a7cfdeef861fcce49ea79357ba825d95d56d67597bc9cc9a473438f5607908186fc477fdeafc68f387552061ebf57d6e585317d5047a57bd496034ff854a417236776003bcba328fa8bf4a024c4d212ba4fb4033ebfb14116c12cde63d16551b9f48c20ee54a417deb")]
+[assembly: InternalsVisibleTo("LaunchDarkly.EventSource.Tests")]

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -4,8 +4,6 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <Copyright>Copyright © 2017 Catamorphic, Co.</Copyright>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../LaunchDarkly.EventSource.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +12,12 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
-  <ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)'=='Release'">
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>../../LaunchDarkly.EventSource.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+
+	<ItemGroup>
     <ProjectReference Include="..\..\src\LaunchDarkly.EventSource\LaunchDarkly.EventSource.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- published version is signed
- however, users don't have the key to sign the project locally
- the assembly info prev only allowed testing from a signed EventSource.Tests
- now, allows building tests in debug mode w/o signing, and allows access from unsigned EventSource.Tests
- theoretically possible for outsiders to create an unrelated EventSource.Tests to get internal access to EventSource, but those variables are already accessible through reflection