### PR TITLE
bump targeted platform versions to .NET Framework 4.5.2, .NET Standard 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,5 +15,5 @@ jobs:
       - checkout
       - run: aws s3 cp s3://launchdarkly-pastebin/ci/dotnet/LaunchDarkly.EventSource.snk LaunchDarkly.EventSource.snk
       - run: dotnet restore
-      - run: dotnet build src/LaunchDarkly.EventSource -f netstandard1.4
+      - run: dotnet build src/LaunchDarkly.EventSource -f netstandard2.0
       - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f netcoreapp2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ workflows:
     jobs:
       - test-netcore-2-1
 
-orbs:
-  win: circleci/windows@1.0.0
-
 jobs:
   test-netcore-2-1:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,19 @@
-version: 2
+version: 2.1
+
 workflows:
   version: 2
   test:
     jobs:
-      - test-2.0
+      - test-netcore-2-1
+      - test-windows-netframework-4-5-2
+
+orbs:
+  win: circleci/windows@1.0.0
+
 jobs:
-  test-2.0:
+  test-netcore-2-1:
     docker:
-      - image: microsoft/dotnet:2.0-sdk-jessie
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
     steps:
       - run:
           name: install packages
@@ -16,4 +22,20 @@ jobs:
       - run: aws s3 cp s3://launchdarkly-pastebin/ci/dotnet/LaunchDarkly.EventSource.snk LaunchDarkly.EventSource.snk
       - run: dotnet restore
       - run: dotnet build src/LaunchDarkly.EventSource -f netstandard2.0
-      - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f netcoreapp2.0
+      - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f netcoreapp2.1
+
+  test-windows-netframework-4-5-2:
+    executor:
+      name: win/vs2019
+      shell: powershell.exe
+    steps:
+      - checkout
+      - run:
+          name: install project dependencies
+          command: dotnet restore
+      - run:
+          name: build for .NET Framework 4.5.2
+          command: dotnet build src/LaunchDarkly.EventSource -f net452
+      - run:
+          name: run tests in .NET Framework 4.6
+          command: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f net46

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ workflows:
   test:
     jobs:
       - test-netcore-2-1
-      - test-windows-netframework-4-5-2
 
 orbs:
   win: circleci/windows@1.0.0
@@ -22,19 +21,3 @@ jobs:
       - run: dotnet restore
       - run: dotnet build src/LaunchDarkly.EventSource -f netstandard2.0
       - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f netcoreapp2.1
-
-  test-windows-netframework-4-5-2:
-    executor:
-      name: win/vs2019
-      shell: powershell.exe
-    steps:
-      - checkout
-      - run:
-          name: install project dependencies
-          command: dotnet restore
-      - run:
-          name: build for .NET Framework 4.5.2
-          command: dotnet build src/LaunchDarkly.EventSource -f net452
-      - run:
-          name: run tests in .NET Framework 4.6
-          command: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f net46

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Development notes
 
 This project imports the `dotnet-base` repository as a subtree. See the `README.md` file in that directory for more information.
 
-Releases are done using the release script in `dotnet-base`. Since the published package includes a .NET Framework 4.5 build, the release must be done from Windows.
+Releases are done using the release script in `dotnet-base`. Since the published package includes a .NET Framework build, the release must be done from Windows.
 
 About LaunchDarkly
 ------------------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Project Information
 
 This libary allows .NET developers to consume Server Sent Events from a remote API. The server sent events spec is defined here: [https://html.spec.whatwg.org/multipage/server-sent-events.html](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events)
 
-This library supports .NET 4.5+ and .NET Standard 1.4+.
+This library supports .NET 4.5.2+ and .NET Standard 2.0+.
 
 Quick setup
 -----------

--- a/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
+++ b/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
@@ -18,6 +18,12 @@
     <PackageReference Include="Common.Logging" Version="3.4.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../LaunchDarkly.EventSource.snk</AssemblyOriginatorKeyFile>

--- a/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
+++ b/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>3.3.2</Version>
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <PackageLicenseUrl>https://raw.github.com/LaunchDarkly/dotnet-eventsource/master/LICENSE</PackageLicenseUrl>
     <AssemblyName>LaunchDarkly.EventSource</AssemblyName>
     <DebugType>portable</DebugType>
@@ -16,12 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -12,6 +12,12 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>../../LaunchDarkly.EventSource.snk</AssemblyOriginatorKeyFile>

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1,net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <Copyright>Copyright © 2017 Catamorphic, Co.</Copyright>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1,net46</TargetFrameworks>
     <Copyright>Copyright © 2017 Catamorphic, Co.</Copyright>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>../../LaunchDarkly.EventSource.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
This removes support for .NET Framework 4.5 and 4.5.1, which have been EOL since 2016, and .NET Standard 1.x, which was only in versions of .NET Core that are now EOL.

Note that we don't currently have a CI build that runs in Windows. We should add one, but there's something about the current test code that doesn't work right in Windows which I'm still trying to figure out.