### PR TITLE
add .NET Standard 2.0 target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,5 +14,5 @@ jobs:
           command: apt-get -q update && apt-get install -qy awscli
       - checkout
       - run: dotnet restore
-      - run: dotnet build src/LaunchDarkly.EventSource -f netstandard1.4
+      - run: dotnet build src/LaunchDarkly.EventSource -f netstandard2.0
       - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f netcoreapp2.0

--- a/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
+++ b/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>3.3.2</Version>
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.github.com/LaunchDarkly/dotnet-eventsource/master/LICENSE</PackageLicenseUrl>
     <AssemblyName>LaunchDarkly.EventSource</AssemblyName>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
This simply adds .NET Standard 2.0 as a target so that the published package will include builds for .NET Standard 1.4, .NET Standard 2.0, and .NET Framework 4.5.

This is different from https://github.com/launchdarkly/dotnet-eventsource/pull/57, which removes .NET Standard 1.4 and also bumps the Framework version to 4.5.2. That one is intended for the next major version release; this one will be merged first and is for the current major version. The goal is to ensure that application code targeted to .NET Standard 2.0 / .NET Core 2.0 (or higher) does not have to link to .NET Standard 1.x assemblies (see https://github.com/launchdarkly/dotnet-eventsource/issues/58). Other than that, there are no functional differences between the 1.4 and 2.0 targets.