### PR TITLE
(4.0) use LaunchDarkly.Logging

### DIFF
--- a/src/LaunchDarkly.EventSource/Configuration.cs
+++ b/src/LaunchDarkly.EventSource/Configuration.cs
@@ -1,8 +1,8 @@
-﻿using Common.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
+using LaunchDarkly.Logging;
 
 namespace LaunchDarkly.EventSource
 {
@@ -24,6 +24,13 @@ namespace LaunchDarkly.EventSource
         public static readonly TimeSpan DefaultReadTimeout = TimeSpan.FromMinutes(5);
         public static readonly TimeSpan MaximumRetryDuration = TimeSpan.FromMilliseconds(30000);
         public static readonly TimeSpan DefaultBackoffResetThreshold = TimeSpan.FromMinutes(1);
+
+        /// <summary>
+        /// The logger name that will be used if you specified a logging implementation but did not
+        /// provide a specific logger instance.
+        /// </summary>
+        /// <seealso cref="ConfigurationBuilder.LogAdapter(ILogAdapter)"/>
+        public const string DefaultLoggerName = "EventSource";
 
         #endregion
 
@@ -69,9 +76,12 @@ namespace LaunchDarkly.EventSource
         public string LastEventId { get; }
 
         /// <summary>
-        /// A custom logger to be used for all EventSource log output.
+        /// The logger to be used for all EventSource log output.
         /// </summary>
-        public ILog Logger { get; }
+        /// <remarks>
+        /// This is never null; if logging is not configured, it will be <c>LaunchDarkly.Logging.Logs.None</c>.
+        /// </remarks>
+        public Logger Logger { get; }
 
         /// <summary>
         /// The request headers to be sent with each EventSource HTTP request.
@@ -137,7 +147,7 @@ namespace LaunchDarkly.EventSource
         ///     <p><paramref name="readTimeout"/> is less than zero. </p>
         /// </exception>
         public Configuration(Uri uri, HttpMessageHandler messageHandler = null, TimeSpan? connectionTimeout = null, TimeSpan? delayRetryDuration = null,
-            TimeSpan? readTimeout = null, IDictionary<string, string> requestHeaders = null, string lastEventId = null, ILog logger = null,
+            TimeSpan? readTimeout = null, IDictionary<string, string> requestHeaders = null, string lastEventId = null, Logger logger = null,
             HttpMethod method = null, HttpContentFactory requestBodyFactory = null, TimeSpan? backoffResetThreshold = null)
         {
             if (uri == null)
@@ -166,7 +176,7 @@ namespace LaunchDarkly.EventSource
             ReadTimeout = readTimeout ?? DefaultReadTimeout;
             RequestHeaders = requestHeaders;
             LastEventId = lastEventId;
-            Logger = logger;
+            Logger = logger ?? Logs.None.Logger("");
             Method = method;
             RequestBodyFactory = requestBodyFactory;
         }

--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -1,9 +1,9 @@
-﻿using Common.Logging;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using LaunchDarkly.Logging;
 
 namespace LaunchDarkly.EventSource
 {
@@ -17,7 +17,7 @@ namespace LaunchDarkly.EventSource
 
         private readonly Configuration _configuration;
         private readonly HttpClient _httpClient;
-        private readonly ILog _logger;
+        private readonly Logger _logger;
 
         private List<string> _eventBuffer;
         private string _eventName = Constants.MessageField;
@@ -104,7 +104,7 @@ namespace LaunchDarkly.EventSource
 
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
-            _logger = _configuration.Logger ?? LogManager.GetLogger(typeof(EventSource));
+            _logger = _configuration.Logger;
 
             _retryDelay = _configuration.DelayRetryDuration;
 
@@ -209,7 +209,7 @@ namespace LaunchDarkly.EventSource
             {
                 TimeSpan sleepTime = _backOff.GetNextBackOff();
                 if (sleepTime.TotalMilliseconds > 0) {
-                    _logger.InfoFormat("Waiting {0} milliseconds before reconnecting...", sleepTime.TotalMilliseconds);
+                    _logger.Info("Waiting {0} milliseconds before reconnecting...", sleepTime.TotalMilliseconds);
                     BackOffDelay = sleepTime;
                     await Task.Delay(sleepTime);
                 }
@@ -300,7 +300,7 @@ namespace LaunchDarkly.EventSource
 
         private void Close(ReadyState state)
         {
-            _logger.DebugFormat("Close({0}) - state was {1}", state, ReadyState);
+            _logger.Debug("Close({0}) - state was {1}", state, ReadyState);
             SetReadyState(state, OnClosed);
         }
         
@@ -380,7 +380,7 @@ namespace LaunchDarkly.EventSource
             _eventBuffer.RemoveAll(item => item.Equals("\n"));
 
             var message = new MessageEvent(string.Concat(_eventBuffer), _lastEventId, _configuration.Uri);
-            _logger.DebugFormat("Received event \"{0}\"", _eventName);
+            _logger.Debug("Received event \"{0}\"", _eventName);
 
             OnMessageReceived(new MessageReceivedEventArgs(message, _eventName));
 

--- a/src/LaunchDarkly.EventSource/EventSourceService.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceService.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Common.Logging;
+using LaunchDarkly.Logging;
 
 namespace LaunchDarkly.EventSource
 {
@@ -15,7 +15,7 @@ namespace LaunchDarkly.EventSource
 
         private readonly Configuration _configuration;
         private readonly HttpClient _httpClient;
-        private readonly ILog _logger;
+        private readonly Logger _logger;
 
         private const string UserAgentProduct = "DotNetClient";
         internal static readonly string UserAgentVersion = ((AssemblyInformationalVersionAttribute)typeof(EventSource)
@@ -48,7 +48,7 @@ namespace LaunchDarkly.EventSource
         /// <exception cref="ArgumentNullException">client
         /// or
         /// configuration</exception>
-        public EventSourceService(Configuration configuration, HttpClient httpClient, ILog logger)
+        public EventSourceService(Configuration configuration, HttpClient httpClient, Logger logger)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -76,7 +76,7 @@ namespace LaunchDarkly.EventSource
 
         private async Task ConnectToEventSourceApi(Action<string> processResponse, string lastEventId, CancellationToken cancellationToken)
         {
-            _logger.DebugFormat("Making {0} request to EventSource URI {1}",
+            _logger.Debug("Making {0} request to EventSource URI {1}",
                 _configuration.Method ?? HttpMethod.Get,
                 _configuration.Uri);
 
@@ -84,7 +84,7 @@ namespace LaunchDarkly.EventSource
                 HttpCompletionOption.ResponseHeadersRead,
                 cancellationToken).ConfigureAwait(false))
             {
-                _logger.DebugFormat("Response status: {0}", (int)response.StatusCode);
+                _logger.Debug("Response status: {0}", (int)response.StatusCode);
                 HandleInvalidResponses(response);
 
                 OnConnectionOpened();

--- a/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
+++ b/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Common.Logging" Version="3.4.1" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
@@ -43,5 +43,4 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
 </Project>

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceLoggingTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceLoggingTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Linq;
+using System.Threading; 
+using LaunchDarkly.Logging;
+using Xunit;
+
+namespace LaunchDarkly.EventSource.Tests
+{
+    public class EventSourceLoggingTests
+    {
+        private readonly Uri _uri = new Uri("http://test.com");
+
+        [Fact]
+        public void UsesDefaultLoggerNameWhenLogAdapterIsSpecified()
+        {
+            var logCapture = Logs.Capture();
+
+            var config = new ConfigurationBuilder(_uri)
+                .MessageHandler(HandlerWithBasicEvent())
+                .LogAdapter(logCapture)
+                .Build();
+
+            using (var es = new EventSource(config))
+            {
+                var opened = new EventWaitHandle(false, EventResetMode.ManualReset);
+                es.Opened += (sender, e) => opened.Set();
+
+                _ = es.StartAsync();
+                opened.WaitOne();
+
+                Assert.NotEmpty(logCapture.GetMessages());
+                Assert.True(logCapture.GetMessages().All(m => m.LoggerName == Configuration.DefaultLoggerName));
+            }
+        }
+
+        [Fact]
+        public void CanSpecifyLoggerInstance()
+        {
+            var logCapture = Logs.Capture();
+            var logger = logCapture.Logger("special");
+
+            var config = new ConfigurationBuilder(_uri)
+                .MessageHandler(HandlerWithBasicEvent())
+                .Logger(logger)
+                .Build();
+
+            using (var es = new EventSource(config))
+            {
+                var opened = new EventWaitHandle(false, EventResetMode.ManualReset);
+                es.Opened += (sender, e) => opened.Set();
+
+                _ = es.StartAsync();
+                opened.WaitOne();
+
+                Assert.NotEmpty(logCapture.GetMessages());
+                Assert.True(logCapture.GetMessages().All(m => m.LoggerName == "special"));
+            }
+        }
+
+
+        [Fact]
+        public void ConnectingLogMessage()
+        {
+            var logCapture = Logs.Capture();
+
+            var config = new ConfigurationBuilder(_uri)
+                .MessageHandler(HandlerWithBasicEvent())
+                .LogAdapter(logCapture)
+                .Build();
+
+            using (var es = new EventSource(config))
+            {
+                var opened = new EventWaitHandle(false, EventResetMode.ManualReset);
+                es.Opened += (sender, e) => opened.Set();
+
+                _ = es.StartAsync();
+                opened.WaitOne();
+
+                Assert.True(logCapture.HasMessageWithText(LogLevel.Debug,
+                    "Making GET request to EventSource URI " + _uri),
+                    logCapture.ToString());
+            }
+        }
+
+        [Fact]
+        public void EventReceivedLogMessage()
+        {
+            var logCapture = Logs.Capture();
+
+            var config = new ConfigurationBuilder(_uri)
+                .MessageHandler(HandlerWithBasicEvent())
+                .LogAdapter(logCapture)
+                .Build();
+
+            using (var es = new EventSource(config))
+            {
+                var received = new EventWaitHandle(false, EventResetMode.ManualReset);
+                es.MessageReceived += (sender, e) => received.Set();
+
+                _ = es.StartAsync();
+                received.WaitOne();
+
+                Assert.True(logCapture.HasMessageWithText(LogLevel.Debug,
+                    "Received event \"thing\""),
+                    logCapture.ToString());
+            }
+        }
+
+        private StubMessageHandler HandlerWithBasicEvent()
+        {
+            var handler = new StubMessageHandler();
+            handler.QueueResponse(StubResponse.StartStream(StreamAction.Write("event: thing\ndata: test\n\n")));
+            return handler;
+        }
+    }
+}


### PR DESCRIPTION
This migrates EventSource to the LaunchDarkly.Logging abstraction that we're planning to use for our .NET-based libraries in the future, removing the dependency on Common.Logging (we will be releasing an adapter so that LaunchDarkly.Logging can be bridged to Common.Logging very simply). This is using an alpha version as the library isn't in GA yet.

This PR doesn't change EventSource's current logging behavior in any other way. We'll probably want to add more detail to the log output and revise some of its phrasing, but this PR is just about the API it uses.