### PR TITLE
Usage of custom httpClient

### DIFF
--- a/src/LaunchDarkly.EventSource/ConfigurationBuilder.cs
+++ b/src/LaunchDarkly.EventSource/ConfigurationBuilder.cs
@@ -23,7 +23,7 @@ namespace LaunchDarkly.EventSource
         #region Private Fields
 
         private readonly Uri _uri;
-        private TimeSpan _connectionTimeout = Configuration.DefaultConnectionTimeout;
+        private TimeSpan? _connectionTimeout = Configuration.DefaultConnectionTimeout;
         private TimeSpan _delayRetryDuration = Configuration.DefaultDelayRetryDuration;
         private TimeSpan _backoffResetThreshold = Configuration.DefaultBackoffResetThreshold;
         private TimeSpan _readTimeout = Configuration.DefaultReadTimeout;
@@ -31,6 +31,7 @@ namespace LaunchDarkly.EventSource
         private ILog _logger;
         private IDictionary<string, string> _requestHeaders = new Dictionary<string, string>();
         private HttpMessageHandler _messageHandler;
+        private HttpClient _httpClient;
         private HttpMethod _method = HttpMethod.Get;
         private Configuration.HttpContentFactory _requestBodyFactory;
 
@@ -58,7 +59,7 @@ namespace LaunchDarkly.EventSource
         public Configuration Build()
         {
             return new Configuration(_uri, _messageHandler, _connectionTimeout, _delayRetryDuration, _readTimeout,
-                _requestHeaders, _lastEventId, _logger, _method, _requestBodyFactory);
+                _requestHeaders, _lastEventId, _logger, _method, _requestBodyFactory, httpClient:_httpClient);
         }
 
         /// <summary>
@@ -196,6 +197,21 @@ namespace LaunchDarkly.EventSource
         }
 
         /// <summary>
+        /// Sets the HttpClient that will be used for the API Calls, or null for a new HttpClient.
+        /// </summary>
+        /// <remarks>
+        /// Setting this, you have to take care of disposing the httpClient and the connection timeout (httpClient.Timeout) yourself.
+        /// </remarks>
+        /// <param name="client">the httpClient</param>
+        /// <returns>the builder</returns>
+        public ConfigurationBuilder HttpClient(HttpClient client)
+        {
+            this._httpClient = client;
+            this._connectionTimeout = null;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the HTTP method that will be used when connecting to the EventSource API.
         /// </summary>
         /// <remarks>
@@ -234,5 +250,6 @@ namespace LaunchDarkly.EventSource
         }
 
         #endregion
+
     }
 }

--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -111,7 +111,7 @@ namespace LaunchDarkly.EventSource
             _backOff = new ExponentialBackoffWithDecorrelation(_retryDelay,
                 Configuration.MaximumRetryDuration);
 
-            _httpClient = CreateHttpClient();
+            _httpClient = _configuration.HttpClient ?? CreateHttpClient();
         }
 
         #endregion
@@ -226,7 +226,12 @@ namespace LaunchDarkly.EventSource
                 Close(ReadyState.Shutdown);
             }
             CancelCurrentRequest();
-            _httpClient.Dispose();
+
+            // do not dispose httpClient if it is user provided
+            if (_configuration.HttpClient == null)
+            {
+                _httpClient.Dispose();
+            }
         }
 
         /// <summary>

--- a/src/LaunchDarkly.EventSource/Resources.Designer.cs
+++ b/src/LaunchDarkly.EventSource/Resources.Designer.cs
@@ -20,7 +20,7 @@ namespace LaunchDarkly.EventSource {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -58,6 +58,24 @@ namespace LaunchDarkly.EventSource {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HttpClient can not be used with ConnectionTimeout. Use Timeout property of httpClient instead..
+        /// </summary>
+        internal static string Configuration_HttpClient_With_ConnectionTimeout {
+            get {
+                return ResourceManager.GetString("Configuration_HttpClient_With_ConnectionTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to HttpClient can not be used with MessageHandler..
+        /// </summary>
+        internal static string Configuration_HttpClient_With_MessageHandler {
+            get {
+                return ResourceManager.GetString("Configuration_HttpClient_With_MessageHandler", resourceCulture);
             }
         }
         

--- a/src/LaunchDarkly.EventSource/Resources.resx
+++ b/src/LaunchDarkly.EventSource/Resources.resx
@@ -123,6 +123,12 @@
   <data name="Configuration_Value_Greater_Than_Zero" xml:space="preserve">
     <value>Value must be greater than zero.</value>
   </data>
+  <data name="Configuration_HttpClient_With_MessageHandler" xml:space="preserve">
+    <value>HttpClient can not be used with MessageHandler.</value>
+  </data>
+  <data name="Configuration_HttpClient_With_ConnectionTimeout" xml:space="preserve">
+    <value>HttpClient can not be used with ConnectionTimeout. Use Timeout property of httpClient instead.</value>
+  </data>
   <data name="EventSourceService_Read_Timeout" xml:space="preserve">
     <value>A timeout occurred while reading the request from the remote EventSource API</value>
   </data>

--- a/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTests.cs
@@ -193,6 +193,20 @@ namespace LaunchDarkly.EventSource.Tests
         }
 
         [Fact]
+        public void HttpClientDefaultsToNull()
+        {
+            Assert.Null(Configuration.Builder(uri).Build().HttpClient);
+        }
+
+        [Fact]
+        public void BuilderSetsHttpClient()
+        {
+            var h = new HttpClient();
+            var b = Configuration.Builder(uri).HttpClient(h);
+            Assert.Same(h, b.Build().HttpClient);
+        }
+        
+        [Fact]
         public void MethodDefaultsToGet()
         {
             var b = Configuration.Builder(uri);

--- a/test/LaunchDarkly.EventSource.Tests/ConfigurationTests.cs
+++ b/test/LaunchDarkly.EventSource.Tests/ConfigurationTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net.Http;
+
 using Xunit;
 
 
@@ -15,6 +17,30 @@ namespace LaunchDarkly.EventSource.Tests
 
             Assert.NotNull(e);
             Assert.IsType<ArgumentNullException>(e);
+        }
+
+        [Fact]
+        public void Configuration_constructor_throws_exception_when_http_client_and_messageHandler_is_provided()
+        {
+            var stubMessageHandler = new StubMessageHandler();
+            var e = Record.Exception(() =>
+                new Configuration(uri: _uri, 
+                    httpClient: new HttpClient(stubMessageHandler), 
+                    messageHandler: stubMessageHandler));
+
+            Assert.IsType<ArgumentException>(e);
+        }
+
+        [Fact]
+        public void Configuration_constructor_throws_exception_when_http_client_and_connectionTimeout_is_provided()
+        {
+            var stubMessageHandler = new StubMessageHandler();
+            var e = Record.Exception(() =>
+                new Configuration(uri: _uri, 
+                    httpClient: new HttpClient(stubMessageHandler), 
+                    connectionTimeout: TimeSpan.Zero));
+
+            Assert.IsType<ArgumentException>(e);
         }
 
         [Fact]


### PR DESCRIPTION
This enables the usage of an existing httpClient. This can be useful if you can not provide an apropriate MessageHandler. In my specific case I have to reuse an exiting httpClient with some included security handlers. This existing httpClient is provided by a (external) factory so i can not provide the handlers to the eventsource myself.