### PR TITLE
make CI tests work in Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ workflows:
           name: .NET Core 3.1
           docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
           test-target-framework: netcoreapp3.1
+      - test-netcore:
+          name: .NET 5.0
+          docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
+          test-target-framework: net5.0
       - test-windows-netframework-4-6-1:
           name: .NET Framework 4.6.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,50 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@1.0.0
+
 workflows:
   version: 2
   test:
     jobs:
-      - test-netcore-2-1
+      - test-netcore:
+          name: .NET Core 2.1
+          docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+          test-target-framework: netcoreapp2.1
+      - test-netcore:
+          name: .NET Core 3.1
+          docker-image: mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+          test-target-framework: netcoreapp3.1
+      - test-windows-netframework-4-6-1:
+          name: .NET Framework 4.6.1
 
 jobs:
-  test-netcore-2-1:
+  test-netcore:
+    parameters:
+      docker-image:
+        type: string
+      test-target-framework:
+        type: string
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
+      - image: <<parameters.docker-image>>
+    environment:
+      ASPNETCORE_SUPPRESSSTATUSMESSAGES: true
+      TESTFRAMEWORK: <<parameters.test-target-framework>>
     steps:
       - run:
           name: install packages
           command: apt-get -q update && apt-get install -qy awscli
       - checkout
-      - run: dotnet restore
       - run: dotnet build src/LaunchDarkly.EventSource -f netstandard2.0
-      - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f netcoreapp2.1
+      - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f <<parameters.test-target-framework>>
+
+  test-windows-netframework-4-6-1:
+    executor:
+      name: win/vs2019
+      shell: powershell.exe
+    environment:
+      TESTFRAMEWORK: net461
+    steps:
+      - checkout
+      - run: dotnet build src/LaunchDarkly.EventSource -f net452
+      - run: dotnet test test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj -f net461

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceEndToEndTest.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceEndToEndTest.cs
@@ -29,100 +29,78 @@ namespace LaunchDarkly.EventSource.Tests
             // parsed correctly regardless of how the chunks line up with the events.
 
             var eventData = new List<string>();
-            var chunks = new List<string>();
             for (var i = 0; i < 200; i++)
             {
                 eventData.Add(string.Format("data{0}", i) + new string('x', i % 7));
             }
             var allBody = string.Concat(eventData.Select(data => "data:" + data + "\n\n"));
-            for (var pos = 0; ;)
+            var allEventsReceived = new EventWaitHandle(false, EventResetMode.ManualReset);
+
+            IEnumerable<string> DoChunks()
             {
-                int i = chunks.Count;
-                int chunkSize = i % 20 + 1;
-                if (pos + chunkSize >= allBody.Length)
+                var i = 0;
+                for (var pos = 0; ;)
                 {
-                    chunks.Add(allBody.Substring(pos));
-                    break;
+                    int chunkSize = i % 20 + 1;
+                    if (pos + chunkSize >= allBody.Length)
+                    {
+                        yield return allBody.Substring(pos);
+                        break;
+                    }
+                    yield return allBody.Substring(pos, chunkSize);
+                    pos += chunkSize;
+                    i++;
                 }
-                chunks.Add(allBody.Substring(pos, chunkSize));
-                pos += chunkSize;
+                allEventsReceived.WaitOne();
             }
 
-            using (var server = StartWebServerOnAvailablePort(out var uri, ctx =>
+            try
             {
-                ctx.Response.ContentType = "text/event-stream";
-                ctx.Response.SendChunked = true;
-                var stream = ctx.Response.OutputStream;
-                foreach (var chunk in chunks)
+                using (var server = StartWebServerOnAvailablePort(out var uri,
+                    RespondWithChunks("text/event-stream", DoChunks)))
                 {
-                    WriteChunk(stream, chunk);
-                }
-            }))
-            {
-                var expectedActions = new List<EventSink.Action>();
-                expectedActions.Add(EventSink.OpenedAction());
-                foreach (var data in eventData)
-                {
-                    expectedActions.Add(EventSink.MessageReceivedAction(new MessageEvent(MessageEvent.DefaultName, data, uri)));
-                }
+                    var expectedActions = new List<EventSink.Action>();
+                    expectedActions.Add(EventSink.OpenedAction());
+                    foreach (var data in eventData)
+                    {
+                        expectedActions.Add(EventSink.MessageReceivedAction(new MessageEvent(MessageEvent.DefaultName, data, uri)));
+                    }
 
-                var config = Configuration.Builder(uri).LogAdapter(_testLogging).Build();
-                using (var es = new EventSource(config))
-                {
-                    var sink = new EventSink(es);
-                    _ = es.StartAsync();
-                    sink.ExpectActions(expectedActions.ToArray());
+                    var config = Configuration.Builder(uri).LogAdapter(_testLogging).Build();
+                    using (var es = new EventSource(config))
+                    {
+                        var sink = new EventSink(es);
+                        _ = es.StartAsync();
+                        sink.ExpectActions(expectedActions.ToArray());
+                    }
                 }
             }
-        }
-
-        [Fact]
-        public void ReadTimeoutIsDetectedInDefaultStringStreamReadingMode()
-        {
-            TimeSpan readTimeout = TimeSpan.FromMilliseconds(200);
-            using (var server = StartWebServerOnAvailablePort(out var uri, ctx =>
+            finally
             {
-                ctx.Response.ContentType = "text/event-stream";
-                ctx.Response.SendChunked = true;
-                var stream = ctx.Response.OutputStream;
-                WriteChunk(stream, "data: event1\n\ndata: e");
-                Thread.Sleep(readTimeout + readTimeout);
-                WriteChunk(stream, "vent2\n\n");
-            }))
-            {
-                var config = Configuration.Builder(uri).LogAdapter(_testLogging)
-                    .ReadTimeout(readTimeout).Build();
-                using (var es = new EventSource(config))
-                {
-                    var sink = new EventSink(es) { Output = _testLogger.Debug };
-                    _ = es.StartAsync();
-                    sink.ExpectActions(
-                        EventSink.OpenedAction(),
-                        EventSink.MessageReceivedAction(new MessageEvent(MessageEvent.DefaultName, "event1", uri)),
-                        EventSink.ErrorAction(new ReadTimeoutException()),
-                        EventSink.ClosedAction()
-                        );
-                }
+                allEventsReceived.Set();
             }
         }
 
-        [Fact]
-        public void ReadTimeoutIsDetectedInRawUtf8ReadingMode()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ReadTimeoutIsDetected(bool utf8Mode)
         {
-            TimeSpan readTimeout = TimeSpan.FromMilliseconds(200);
-            using (var server = StartWebServerOnAvailablePort(out var uri, ctx =>
+            TimeSpan readTimeout = TimeSpan.FromMilliseconds(2000);
+            IEnumerable<string> DoChunks()
             {
-                ctx.Response.ContentType = "text/event-stream";
-                ctx.Response.SendChunked = true;
-                var stream = ctx.Response.OutputStream;
-                WriteChunk(stream, "data: event1\n\ndata: e");
+                yield return "";
+                yield return "data: event1\n\ndata: e";
                 Thread.Sleep(readTimeout + readTimeout);
-                WriteChunk(stream, "vent2\n\n");
-            }))
+                yield return "vent2\n\n";
+            }
+            using (var server = StartWebServerOnAvailablePort(out var uri, RespondWithChunks("text/event-stream", DoChunks)))
             {
-                var config = Configuration.Builder(uri).LogAdapter(_testLogging)
+                var config = Configuration.Builder(uri)
+                    .LogAdapter(_testLogging)
                     .ReadTimeout(readTimeout)
-                    .DefaultEncoding(Encoding.UTF8).PreferDataAsUtf8Bytes(true).Build();
+                    .PreferDataAsUtf8Bytes(utf8Mode)
+                    .Build();
                 using (var es = new EventSource(config))
                 {
                     var sink = new EventSink(es) { Output = _testLogger.Debug };
@@ -135,13 +113,6 @@ namespace LaunchDarkly.EventSource.Tests
                         );
                 }
             }
-        }
-
-        private static void WriteChunk(Stream stream, string data)
-        {
-            var bytes = Encoding.UTF8.GetBytes(data);
-            stream.Write(bytes, 0, bytes.Length);
-            stream.Flush();
         }
 
         private static WebServer StartWebServerOnAvailablePort(out Uri serverUri, Action<IHttpContext> handler)
@@ -150,7 +121,10 @@ namespace LaunchDarkly.EventSource.Tests
 
             for (int port = 10000; ; port++)
             {
-                var server = new WebServer(port).WithModule(module);
+                var options = new WebServerOptions()
+                    .WithUrlPrefix($"http://*:{port}")
+                    .WithMode(HttpListenerMode.EmbedIO);
+                var server = new WebServer(options).WithModule(module);
                 try
                 {
                     _ = server.RunAsync();
@@ -163,6 +137,20 @@ namespace LaunchDarkly.EventSource.Tests
                 return server;
             }
         }
+
+        private static Action<IHttpContext> RespondWithChunks(string contentType, Func<IEnumerable<string>> chunks) =>
+            ctx =>
+            {
+                ctx.Response.ContentType = contentType;
+                ctx.Response.SendChunked = true;
+                var stream = ctx.Response.OutputStream;
+                foreach (var chunk in chunks())
+                {
+                    var bytes = Encoding.UTF8.GetBytes(chunk);
+                    stream.Write(bytes, 0, bytes.Length);
+                    stream.Flush();
+                }
+            };
 
         // A simple web server handler for use with EmbedIO, delegating to a function you provide.
         private sealed class SimpleModule : IWebModule

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceEndToEndTest.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceEndToEndTest.cs
@@ -86,7 +86,7 @@ namespace LaunchDarkly.EventSource.Tests
         [InlineData(true)]
         public void ReadTimeoutIsDetected(bool utf8Mode)
         {
-            TimeSpan readTimeout = TimeSpan.FromMilliseconds(2000);
+            TimeSpan readTimeout = TimeSpan.FromMilliseconds(200);
             IEnumerable<string> DoChunks()
             {
                 yield return "";

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceReconnectingTest.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceReconnectingTest.cs
@@ -82,7 +82,7 @@ namespace LaunchDarkly.EventSource.Tests
             {
                 handler.QueueResponse(StubResponse.StartStream(
                     StreamAction.Write(":hi\n"),
-                    StreamAction.CloseStreamAbnormally()));
+                    StreamAction.CloseStream()));
             }
             handler.QueueResponse(StubResponse.StartStream());
 
@@ -91,7 +91,7 @@ namespace LaunchDarkly.EventSource.Tests
             using (var es = MakeEventSource(handler, builder => builder.InitialRetryDelay(TimeSpan.FromMilliseconds(100))))
             {
                 _ = new EventSink(es, _testLogging);
-                es.Error += (_, ex) =>
+                es.Closed += (_, state) =>
                 {
                     backoffs.Add(es.BackOffDelay);
                 };

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <!-- The TESTFRAMEWORK variable allows us to override the target frameworks with a
+         single framework that we are testing; this allows us to test with older SDK
+         versions that would error out if they saw any newer target frameworks listed
+         here, even if we weren't running those. -->
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net461</TestFramework>
+    <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
+
     <Copyright>Copyright © 2017 Catamorphic, Co.</Copyright>
   </PropertyGroup>
 

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -4,7 +4,7 @@
          single framework that we are testing; this allows us to test with older SDK
          versions that would error out if they saw any newer target frameworks listed
          here, even if we weren't running those. -->
-    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net461</TestFramework>
+    <TestFramework Condition="'$(TESTFRAMEWORK)' == ''">netcoreapp2.1;net461</TestFramework>
     <TargetFrameworks>$(TESTFRAMEWORK)</TargetFrameworks>
 
     <Copyright>Copyright © 2017 Catamorphic, Co.</Copyright>

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="EmbedIO" Version="3.4.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/test/LaunchDarkly.EventSource.Tests/Stubs/StubHandler.cs
+++ b/test/LaunchDarkly.EventSource.Tests/Stubs/StubHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Pipelines;
 using System.IO.Pipes;
 using System.Linq;
 using System.Net;
@@ -128,9 +129,9 @@ namespace LaunchDarkly.EventSource.Tests
         override public HttpResponseMessage MakeResponse(CancellationToken cancellationToken)
         {
             var httpResponse = new HttpResponseMessage(HttpStatusCode.OK);
-            var streamRead = new AnonymousPipeServerStream(PipeDirection.In);
-            var streamWrite = new AnonymousPipeClientStream(PipeDirection.Out, streamRead.ClientSafePipeHandle);
-            var content = new StreamContent(streamRead);
+            var pipe = new Pipe();
+            var readStream = pipe.Reader.AsStream(true);
+            var content = new StreamContent(readStream);
             content.Headers.ContentType = new MediaTypeHeaderValue("text/event-stream");
             if (_specifiedEncoding)
             {
@@ -138,12 +139,12 @@ namespace LaunchDarkly.EventSource.Tests
             }
             httpResponse.Content = content;
 
-            Task.Run(() => WriteStreamingResponse(streamWrite, streamRead, cancellationToken));
+            Task.Run(() => WriteStreamingResponse(pipe.Writer, readStream, cancellationToken));
 
             return httpResponse;
         }
         
-        private async Task WriteStreamingResponse(Stream output, Stream readStream, CancellationToken cancellationToken)
+        private async Task WriteStreamingResponse(PipeWriter output, Stream readStream, CancellationToken cancellationToken)
         {
             try
             {
@@ -152,6 +153,7 @@ namespace LaunchDarkly.EventSource.Tests
                     if (action.CloseEarly)
                     {
                         readStream.Close();
+                        output.Complete();
                         return;
                     }
                     if (action.Delay != TimeSpan.Zero)
@@ -160,11 +162,11 @@ namespace LaunchDarkly.EventSource.Tests
                     }
                     if (action.ShouldQuit())
                     {
-                        output.Close();
+                        output.Complete();
                         return;
                     }
                     var data = _encoding.GetBytes(action.Content);
-                    await output.WriteAsync(data, 0, data.Length, cancellationToken);
+                    await output.WriteAsync(new ReadOnlyMemory<byte>(data), cancellationToken);
                 }
                 // if we've run out of actions, leave the stream open until it's cancelled
                 while (!cancellationToken.IsCancellationRequested)

--- a/test/LaunchDarkly.EventSource.Tests/Stubs/StubHandler.cs
+++ b/test/LaunchDarkly.EventSource.Tests/Stubs/StubHandler.cs
@@ -210,9 +210,6 @@ namespace LaunchDarkly.EventSource.Tests
 
         public static StreamAction CloseStream() => new StreamAction();
 
-        public static StreamAction CloseStreamAbnormally() =>
-            new StreamAction { CloseEarly = true };
-
         public StreamAction AfterDelay(TimeSpan delay) =>
             new StreamAction { Content = this.Content, CloseEarly = this.CloseEarly, Delay = delay };
     }


### PR DESCRIPTION
There were two reasons why we didn't have CI tests for this library running in Windows till now:

1. Originally, CircleCI didn't support it.
2. Then, we tried and found out that the WireMock.Net library we were using for an embedded HTTP server had some compatibility problems in .NET Framework.

Those are no longer relevant, but I found a few more test issues - see PR comments.