### PR TITLE
clean up error messages

### DIFF
--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -149,7 +149,7 @@ namespace LaunchDarkly.EventSource
 
                 if (ReadyState == ReadyState.Connecting || ReadyState == ReadyState.Open)
                 {
-                    throw new InvalidOperationException(string.Format(Resources.EventSource_Already_Started, ReadyState));
+                    throw new InvalidOperationException(string.Format(Resources.ErrorAlreadyStarted, ReadyState));
                 }
 
                 SetReadyState(ReadyState.Connecting);

--- a/src/LaunchDarkly.EventSource/EventSourceServiceUnsuccessfulResponseException.cs
+++ b/src/LaunchDarkly.EventSource/EventSourceServiceUnsuccessfulResponseException.cs
@@ -21,9 +21,9 @@ namespace LaunchDarkly.EventSource
         /// <summary>
         /// Creates a new instance.
         /// </summary>
-        /// <param name="message">the exception message</param>
         /// <param name="statusCode">the HTTP status code of the response</param>
-        public EventSourceServiceUnsuccessfulResponseException(string message, int statusCode) : base(message)
+        public EventSourceServiceUnsuccessfulResponseException(int statusCode) :
+            base(string.Format(Resources.ErrorHttpStatus, statusCode))
         {
             StatusCode = statusCode;
         }

--- a/src/LaunchDarkly.EventSource/ReadTimeoutException.cs
+++ b/src/LaunchDarkly.EventSource/ReadTimeoutException.cs
@@ -15,6 +15,6 @@ namespace LaunchDarkly.EventSource
     public class ReadTimeoutException : Exception
     {
         /// <inheritdoc/>
-        public override string Message => Resources.EventSourceService_Read_Timeout;
+        public override string Message => Resources.ErrorReadTimeout;
     }
 }

--- a/src/LaunchDarkly.EventSource/Resources.Designer.cs
+++ b/src/LaunchDarkly.EventSource/Resources.Designer.cs
@@ -47,57 +47,33 @@ namespace LaunchDarkly.EventSource {
             }
         }
         
-        internal static string EventSourceService_Read_Timeout {
+        internal static string ErrorReadTimeout {
             get {
-                return ResourceManager.GetString("EventSourceService_Read_Timeout", resourceCulture);
+                return ResourceManager.GetString("ErrorReadTimeout", resourceCulture);
             }
         }
         
-        internal static string EventSource_204_Response {
+        internal static string ErrorAlreadyStarted {
             get {
-                return ResourceManager.GetString("EventSource_204_Response", resourceCulture);
+                return ResourceManager.GetString("ErrorAlreadyStarted", resourceCulture);
             }
         }
         
-        internal static string EventSource_Already_Started {
+        internal static string ErrorHttpStatus {
             get {
-                return ResourceManager.GetString("EventSource_Already_Started", resourceCulture);
+                return ResourceManager.GetString("ErrorHttpStatus", resourceCulture);
             }
         }
         
-        internal static string EventSource_HttpResponse_Not_Successful {
+        internal static string ErrorWrongContentType {
             get {
-                return ResourceManager.GetString("EventSource_HttpResponse_Not_Successful", resourceCulture);
+                return ResourceManager.GetString("ErrorWrongContentType", resourceCulture);
             }
         }
         
-        internal static string EventSource_Invalid_MediaType {
+        internal static string ErrorEmptyResponse {
             get {
-                return ResourceManager.GetString("EventSource_Invalid_MediaType", resourceCulture);
-            }
-        }
-        
-        internal static string EventSource_Logger_Closed {
-            get {
-                return ResourceManager.GetString("EventSource_Logger_Closed", resourceCulture);
-            }
-        }
-        
-        internal static string EventSource_Logger_Connection_Error {
-            get {
-                return ResourceManager.GetString("EventSource_Logger_Connection_Error", resourceCulture);
-            }
-        }
-        
-        internal static string EventSource_Logger_Disconnected {
-            get {
-                return ResourceManager.GetString("EventSource_Logger_Disconnected", resourceCulture);
-            }
-        }
-        
-        internal static string EventSource_Response_Content_Empty {
-            get {
-                return ResourceManager.GetString("EventSource_Response_Content_Empty", resourceCulture);
+                return ResourceManager.GetString("ErrorEmptyResponse", resourceCulture);
             }
         }
     }

--- a/src/LaunchDarkly.EventSource/Resources.resx
+++ b/src/LaunchDarkly.EventSource/Resources.resx
@@ -117,31 +117,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="EventSourceService_Read_Timeout" xml:space="preserve">
-    <value>A timeout occurred while reading the request from the remote EventSource API</value>
+  <data name="ErrorReadTimeout" xml:space="preserve">
+    <value>Read timeout elapsed with no new data from server; connection may have been silently dropped</value>
   </data>
-  <data name="EventSource_204_Response" xml:space="preserve">
-    <value>Remote EventSource API returned Http Status Code 204.</value>
+  <data name="ErrorAlreadyStarted" xml:space="preserve">
+    <value>Invalid attempt to call Start() while the connection state is {0}</value>
   </data>
-  <data name="EventSource_Already_Started" xml:space="preserve">
-    <value>Invalid attempt to call Start() while the connection is {0}.</value>
+  <data name="ErrorHttpStatus" xml:space="preserve">
+    <value>Unexpected HTTP status code {0} from server</value>
   </data>
-  <data name="EventSource_HttpResponse_Not_Successful" xml:space="preserve">
-    <value>Http Status Code '{0}' indicates an unsuccessful response returned from the remote EventSource API.</value>
+  <data name="ErrorWrongContentType" xml:space="preserve">
+    <value>Unexpected HTTP content type "{0}"; should be "text/event-stream"</value>
   </data>
-  <data name="EventSource_Invalid_MediaType" xml:space="preserve">
-    <value>HTTP Content-Type returned from the remote EventSource API does not match 'text/event-stream'.</value>
-  </data>
-  <data name="EventSource_Logger_Closed" xml:space="preserve">
-    <value>EventSource.Close called</value>
-  </data>
-  <data name="EventSource_Logger_Connection_Error" xml:space="preserve">
-    <value>Encountered exception in EventSourceService.ConnectToEventSourceApi method. Exception Message: {0}</value>
-  </data>
-  <data name="EventSource_Logger_Disconnected" xml:space="preserve">
-    <value>EventSource Disconnected. Automatically delaying {0}ms before reconnecting.</value>
-  </data>
-  <data name="EventSource_Response_Content_Empty" xml:space="preserve">
-    <value>Http Response contained no content.</value>
+  <data name="ErrorEmptyResponse" xml:space="preserve">
+    <value>HTTP response had no body</value>
   </data>
 </root>

--- a/test/LaunchDarkly.EventSource.Tests/AsyncHelpersTest.cs
+++ b/test/LaunchDarkly.EventSource.Tests/AsyncHelpersTest.cs
@@ -53,7 +53,7 @@ namespace LaunchDarkly.EventSource.Tests
                     async (token) =>
                     {
                         await Task.Yield();
-                        throw new EventSourceServiceUnsuccessfulResponseException("", 401);
+                        throw new EventSourceServiceUnsuccessfulResponseException(401);
                     });
             });
         }

--- a/test/LaunchDarkly.EventSource.Tests/EventSourceHttpBehaviorTest.cs
+++ b/test/LaunchDarkly.EventSource.Tests/EventSourceHttpBehaviorTest.cs
@@ -163,7 +163,7 @@ namespace LaunchDarkly.EventSource.Tests
 
                 var errorAction = eventSink.ExpectAction();
                 var ex = Assert.IsType<EventSourceServiceCancelledException>(errorAction.Exception);
-                Assert.Contains("Content-Type", ex.Message);
+                Assert.Matches(".*content type.*text/html", ex.Message);
             }
         }
 


### PR DESCRIPTION
This library's error messages, which date back to a pretty old first version from before we had any style conventions at all, have some idiosyncratic choices:

* Referring to the server endpoint as the "EventSource API" (`A timeout occurred while reading the request from the remote EventSource API`)— that's incorrect, the EventSource API would either be this library's own EventSource class or the _browser JavaScript API_ of the same name; the protocol used by the server is called Server-Sent Events.
* Random capitalization (`Remote EventSource API returned Http Status Code 204.`), (`Http Response contained no content.`)
* Sometimes ending with a period, sometimes not
* The programmatic names for the messages(*) are using underscore delimiters, inconsistent with .NET symbol naming conventions.

(* We're using Visual Studio's resource file mechanism for internationalizable messages, even though we've only provided English-language text; this causes each string to be defined as a named constant in the Resources class.)