### PR TITLE
rename ConnectionTimeout to ResponseStartTimeout

### DIFF
--- a/src/LaunchDarkly.EventSource/Configuration.cs
+++ b/src/LaunchDarkly.EventSource/Configuration.cs
@@ -28,10 +28,16 @@ namespace LaunchDarkly.EventSource
         public static readonly TimeSpan DefaultMaxRetryDelay = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// The default value for <see cref="ConfigurationBuilder.ConnectionTimeout(TimeSpan)"/>:
+        /// The default value for <see cref="ConfigurationBuilder.ResponseStartTimeout(TimeSpan)"/>:
         /// 10 seconds.
         /// </summary>
-        public static readonly TimeSpan DefaultConnectionTimeout = TimeSpan.FromSeconds(10);
+        public static readonly TimeSpan DefaultResponseStartTimeout = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Obsolete name for <see cref="DefaultResponseStartTimeout"/>.
+        /// </summary>
+        [Obsolete("Use DefaultResponseStartTimeout")]
+        public static readonly TimeSpan DefaultConnectionTimeout = DefaultResponseStartTimeout;
 
         /// <summary>
         /// The default value for <see cref="ConfigurationBuilder.ReadTimeout(TimeSpan)"/>:
@@ -63,10 +69,10 @@ namespace LaunchDarkly.EventSource
         public TimeSpan BackoffResetThreshold { get; }
 
         /// <summary>
-        /// the connection timeout value used when connecting to the EventSource API.
+        /// Obsolete name for <see cref="ResponseStartTimeout"/>.
         /// </summary>
-        /// <seealso cref="ConfigurationBuilder.ConnectionTimeout(TimeSpan)"/>
-        public TimeSpan ConnectionTimeout { get; }
+        [Obsolete("Use ResponseStartTimeout")]
+        public TimeSpan ConnectionTimeout => ResponseStartTimeout;
 
         /// <summary>
         /// The character encoding to use when reading the stream if the server did not specify
@@ -148,6 +154,13 @@ namespace LaunchDarkly.EventSource
         public IDictionary<string, string> RequestHeaders { get; }
 
         /// <summary>
+        /// The maximum amount of time to wait between starting an HTTP request and receiving the response
+        /// headers.
+        /// </summary>
+        /// <seealso cref="ConfigurationBuilder.ResponseStartTimeout(TimeSpan)"/>
+        public TimeSpan ResponseStartTimeout { get; }
+
+        /// <summary>
         /// Gets the <see cref="System.Uri"/> used when connecting to an EventSource API.
         /// </summary>
         public Uri Uri { get; }
@@ -164,7 +177,6 @@ namespace LaunchDarkly.EventSource
                 (builder._logAdapter is null ? null : builder._logAdapter.Logger(Configuration.DefaultLoggerName));
 
             BackoffResetThreshold = builder._backoffResetThreshold;
-            ConnectionTimeout = builder._connectionTimeout ?? DefaultConnectionTimeout;
             DefaultEncoding = builder._defaultEncoding ?? Encoding.UTF8;
             HttpClient = builder._httpClient;
             HttpMessageHandler = (builder._httpClient != null) ? null : builder._httpMessageHandler;
@@ -173,9 +185,10 @@ namespace LaunchDarkly.EventSource
             Logger = logger ?? Logs.None.Logger("");
             MaxRetryDelay = builder._maxRetryDelay;
             Method = builder._method;
+            PreferDataAsUtf8Bytes = builder._preferDataAsUtf8Bytes;
             ReadTimeout = builder._readTimeout;
             RequestHeaders = new Dictionary<string, string>(builder._requestHeaders);
-            PreferDataAsUtf8Bytes = builder._preferDataAsUtf8Bytes;
+            ResponseStartTimeout = builder._responseStartTimeout;
             RequestBodyFactory = builder._requestBodyFactory;
         }
 

--- a/src/LaunchDarkly.EventSource/EventSource.cs
+++ b/src/LaunchDarkly.EventSource/EventSource.cs
@@ -270,7 +270,7 @@ namespace LaunchDarkly.EventSource
             var client =_configuration.HttpMessageHandler is null ?
                 new HttpClient() :
                 new HttpClient(_configuration.HttpMessageHandler, false);
-            client.Timeout = _configuration.ConnectionTimeout;
+            client.Timeout = _configuration.ResponseStartTimeout;
             return client;
         }
 

--- a/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTest.cs
+++ b/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTest.cs
@@ -25,36 +25,42 @@ namespace LaunchDarkly.EventSource.Tests
             Assert.IsType<ArgumentNullException>(e);
         }
 
+#pragma warning disable 0618
         [Fact]
-        public void ConnectionTimeoutHasDefault()
+        public void DeprecatedConnectionTimeoutHasDefault()
         {
             var b = Configuration.Builder(uri);
             Assert.Equal(Configuration.DefaultConnectionTimeout, b.Build().ConnectionTimeout);
+            Assert.Equal(Configuration.DefaultConnectionTimeout, b.Build().ResponseStartTimeout);
         }
 
         [Fact]
-        public void BuilderSetsConnectionTimeout()
+        public void BuilderSetsDeprecatedConnectionTimeout()
         {
             var ts = TimeSpan.FromSeconds(9);
             var b = Configuration.Builder(uri).ConnectionTimeout(ts);
             Assert.Equal(ts, b.Build().ConnectionTimeout);
+            Assert.Equal(ts, b.Build().ResponseStartTimeout);
         }
 
         [Fact]
-        public void ConnectionTimeoutCanBeInfinite()
+        public void DeprecatedConnectionTimeoutCanBeInfinite()
         {
             var ts = Timeout.InfiniteTimeSpan;
             var b = Configuration.Builder(uri).ConnectionTimeout(ts);
             Assert.Equal(ts, b.Build().ConnectionTimeout);
+            Assert.Equal(ts, b.Build().ResponseStartTimeout);
         }
 
         [Fact]
-        public void AnyNegativeConnectionTimeoutIsInfinite()
+        public void AnyNegativeDeprecatedConnectionTimeoutIsInfinite()
         {
             var ts = TimeSpan.FromSeconds(-9);
             var b = Configuration.Builder(uri).ConnectionTimeout(ts);
             Assert.Equal(Timeout.InfiniteTimeSpan, b.Build().ConnectionTimeout);
+            Assert.Equal(Timeout.InfiniteTimeSpan, b.Build().ResponseStartTimeout);
         }
+#pragma warning restore 0618
 
         [Fact]
         public void InitialRetryDelayRetryHasDefault()
@@ -131,6 +137,36 @@ namespace LaunchDarkly.EventSource.Tests
             var ts = TimeSpan.FromSeconds(-9);
             var b = Configuration.Builder(uri).ReadTimeout(ts);
             Assert.Equal(Timeout.InfiniteTimeSpan, b.Build().ReadTimeout);
+        }
+        [Fact]
+        public void ResponseStartTimeoutHasDefault()
+        {
+            var b = Configuration.Builder(uri);
+            Assert.Equal(Configuration.DefaultResponseStartTimeout, b.Build().ResponseStartTimeout);
+        }
+
+        [Fact]
+        public void BuilderSetsResponseStartTimeout()
+        {
+            var ts = TimeSpan.FromSeconds(9);
+            var b = Configuration.Builder(uri).ResponseStartTimeout(ts);
+            Assert.Equal(ts, b.Build().ResponseStartTimeout);
+        }
+
+        [Fact]
+        public void ResponseStartTimeoutCanBeInfinite()
+        {
+            var ts = Timeout.InfiniteTimeSpan;
+            var b = Configuration.Builder(uri).ResponseStartTimeout(ts);
+            Assert.Equal(ts, b.Build().ResponseStartTimeout);
+        }
+
+        [Fact]
+        public void AnyNegativeResponseStartTimeoutIsInfinite()
+        {
+            var ts = TimeSpan.FromSeconds(-9);
+            var b = Configuration.Builder(uri).ResponseStartTimeout(ts);
+            Assert.Equal(Timeout.InfiniteTimeSpan, b.Build().ResponseStartTimeout);
         }
 
         [Fact]


### PR DESCRIPTION
One aspect of .NET's HTTP implementation that's different from many other platforms is that it doesn't really have a notion of a distinct TCP connection timeout, or a read (socket) timeout. Those things do exist in its lower-level TCP implementation, but they're not surfaced in HttpClient. We rolled our own implementation of the read timeout for EventSource, but we misleadingly provided a `ConnectionTimeout` property that was being used to set the property `HttpClient.Timeout`... which is not the connection timeout at all, it's "time till we start receiving a response".

_Some_ .NET platforms (.NET Core 2.1+ and .NET 5+) do now have a connection timeout, but not as a property of the client— it's a property of the class `SocketsHttpHandler`. Since EventSource already gives you the ability to specify your own HTTP message handler, anyone who knows they'll be running in one of those platforms can already set it that way. And there will already be some platform-specific stuff in our .NET SDK and Xamarin SDK, so if we really want to implement a connection timeout we can do it there. I think all we ought to do here is provide a less misleading name for the property in the EventSource configuration.