### PR TITLE
use DocFX to generate HTML docs

### DIFF
--- a/.ldrelease/build-docs.ps1
+++ b/.ldrelease/build-docs.ps1
@@ -1,0 +1,75 @@
+
+if (-not (get-Command docfx -errorAction silentlyContinue))
+{
+    choco install docfx
+}
+
+$projectName = dir "${env:LD_RELEASE_PROJECT_DIR}/src" | %{$_.Name}
+
+$tempDocsDir = "${env:LD_RELEASE_TEMP_DIR}/build-docs"
+remove-item $tempDocsDir -recurse -force -errorAction ignore
+new-item -path $tempDocsDir -itemType "directory" | out-null
+set-location $tempDocsDir
+
+# Create a minimal home page
+set-content -path ./index.md @"
+# ${env:LD_RELEASE_DOCS_TITLE}
+
+This site contains the full [API documentation](./api) for `$projectName` (version ${env:LD_RELEASE_VERSION}).
+
+For source code, see the [GitHub repository](https://github.com/launchdarkly/${env:LD_RELEASE_PROJECT}).
+"@
+
+# Create a minimal navigation list that just points to the root of the API
+set-content -path ./toc.yml @"
+- name: API Documentation
+  href: build/api/
+"@
+
+# Create the docfx.json config file
+$docfxConfig = @{
+  metadata = ,
+    @{
+      src = ,
+        @{
+          src = "${env:LD_RELEASE_PROJECT_DIR}/src"
+          files = "**/*.csproj"
+        }
+      dest = "build/api"
+      disableGitFeatures = $false
+      disableDefaultFilter = $false
+    }
+  build = @{
+    content = @{
+        src = "build/api"
+        files = , "**.yml"
+        dest = "api"
+      },
+      @{
+        src = "."
+        files = "toc.yml", "*.md"
+      }
+    overwrite = ,
+      @{
+        files = , "apidoc/**.md"
+        exclude = "obj/**", "html/**"
+      }
+    dest = "build/html"
+    globalMetadata = @{
+      _disableContribution = $true
+    }
+    template = , "default"
+    disableGitFeatures = $true
+  }
+}
+convertTo-json -inputObject $docfxConfig -depth 10 | set-content -path docfx.json 
+
+# Run the documentation generator
+docfx docfx.json
+
+# Make an archive of the output and store it as a single artifact
+# (currently that's what Releaser expects)
+set-location "$tempDocsDir/build/html"
+tar -cvzf "${env:LD_RELEASE_PROJECT_DIR}/artifacts/docs.zip" *
+
+set-location $env:LD_RELEASE_PROJECT_DIR

--- a/.ldrelease/build-docs.ps1
+++ b/.ldrelease/build-docs.ps1
@@ -1,11 +1,32 @@
 
+# Standard PowerShell script for generating HTML documentation with DocFX from any
+# .NET project that uses LaunchDarkly's standard project layout.
+#
+# The variables LD_RELEASE_PROJECT, LD_RELEASE_VERSION, and LD_RELEASE_DOCS_TITLE
+# are set when the release job is configured. The expected output of the build is
+# an archive file called "docs.zip" in "./artifacts".
+
+if ("$env:LD_RELEASE_DOCS_TITLE" -eq "") {
+    Write-Host "Not generating documentation because LD_RELEASE_DOCS_TITLE was not set"
+    exit
+}
+
+# Terminate the script if any PowerShell command fails, or if we use an unknown variable
+$ErrorActionPreference = "Stop"
+set-strictmode -version latest
+
+# Import helper functions and set up paths (helpers.psm1 comes from Releaser's
+# built-in scripts)
+$projectDir = get-location
+$tempDir = "$HOME\temp"
+$scriptDir = split-path -parent $MyInvocation.MyCommand.Definition
+import-module "$scriptDir\circleci\template\helpers.psm1" -force
+
+# Install DocFX
 if (-not (get-Command docfx -errorAction silentlyContinue))
 {
     choco install docfx
 }
-
-$projectDir = $(get-location)
-$tempDir = "$HOME\temp"
 
 $projectName = dir "$projectDir/src" | %{$_.Name}
 
@@ -18,12 +39,18 @@ set-location $tempDocsDir
 set-content -path ./index.md @"
 # ${env:LD_RELEASE_DOCS_TITLE}
 
-This site contains the full [API documentation](./api) for ``$projectName`` (version ${env:LD_RELEASE_VERSION}).
+This site contains the full API reference for ``$projectName`` (version ${env:LD_RELEASE_VERSION}).
+Click "API Documentation" above to see all namespaces and types.
 
 For source code, see the [GitHub repository](https://github.com/launchdarkly/${env:LD_RELEASE_PROJECT}).
 "@
 
-# Create a minimal navigation list that just points to the root of the API
+# Create a minimal navigation list that just points to the root of the API. The path
+# "build/api" does not exist in the built HTML docs-- it refers to the intermediate
+# build metadata; when DocFX resolves this link during HTML generation, it will become
+# a link to the first namespace in the API. Unfortunately, that link resolution appears
+# to only work in the navbar and not in Markdown pages, which is why the "index.md"
+# text above tells people to click on the navbar link.
 set-content -path ./toc.yml @"
 - name: API Documentation
   href: build/api/
@@ -70,9 +97,9 @@ convertTo-json -inputObject $docfxConfig -depth 10 | set-content -path docfx.jso
 # Run the documentation generator
 docfx docfx.json
 
-# Make an archive of the output and store it as a single artifact
-# (currently that's what Releaser expects)
-set-location "$tempDocsDir/build/html"
-tar -cvzf "$projectDir/artifacts/docs.zip" *
+# Make an archive of the output and store it as a single artifact. The
+# built-in CompressArchive command in PowerShell 5 produces archives that
+# aren't valid on other platforms, so we're using a helper from helpers.psm1
+Zip -sourcePath "$tempDocsDir/build/html" -zipFile "$projectDir/artifacts/docs.zip"
 
 set-location $projectDir

--- a/.ldrelease/build-docs.ps1
+++ b/.ldrelease/build-docs.ps1
@@ -18,7 +18,7 @@ set-location $tempDocsDir
 set-content -path ./index.md @"
 # ${env:LD_RELEASE_DOCS_TITLE}
 
-This site contains the full [API documentation](./api) for `$projectName` (version ${env:LD_RELEASE_VERSION}).
+This site contains the full [API documentation](./api) for ``$projectName`` (version ${env:LD_RELEASE_VERSION}).
 
 For source code, see the [GitHub repository](https://github.com/launchdarkly/${env:LD_RELEASE_PROJECT}).
 "@

--- a/.ldrelease/build-docs.ps1
+++ b/.ldrelease/build-docs.ps1
@@ -4,9 +4,12 @@ if (-not (get-Command docfx -errorAction silentlyContinue))
     choco install docfx
 }
 
+$projectDir = $(get-location)
+$tempDir = "$HOME\temp"
+
 $projectName = dir "${env:LD_RELEASE_PROJECT_DIR}/src" | %{$_.Name}
 
-$tempDocsDir = "${env:LD_RELEASE_TEMP_DIR}/build-docs"
+$tempDocsDir = "$tempDir/build-docs"
 remove-item $tempDocsDir -recurse -force -errorAction ignore
 new-item -path $tempDocsDir -itemType "directory" | out-null
 set-location $tempDocsDir
@@ -32,7 +35,7 @@ $docfxConfig = @{
     @{
       src = ,
         @{
-          src = "${env:LD_RELEASE_PROJECT_DIR}/src"
+          src = "$projectDir/src"
           files = "**/*.csproj"
         }
       dest = "build/api"
@@ -70,6 +73,6 @@ docfx docfx.json
 # Make an archive of the output and store it as a single artifact
 # (currently that's what Releaser expects)
 set-location "$tempDocsDir/build/html"
-tar -cvzf "${env:LD_RELEASE_PROJECT_DIR}/artifacts/docs.zip" *
+tar -cvzf "$projectDir/artifacts/docs.zip" *
 
-set-location $env:LD_RELEASE_PROJECT_DIR
+set-location $projectDir

--- a/.ldrelease/build-docs.ps1
+++ b/.ldrelease/build-docs.ps1
@@ -57,42 +57,43 @@ set-content -path ./toc.yml @"
 "@
 
 # Create the docfx.json config file
-$docfxConfig = @{
-  metadata = ,
-    @{
-      src = ,
-        @{
-          src = "$projectDir/src"
-          files = "**/*.csproj"
+$jsonEscapedSrcPath = convertTo-json -inputObject "$projectDir/src"
+set-content -path docfx.json @"
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": $jsonEscapedSrcPath,
+          "files": "**/*.csproj"
         }
-      dest = "build/api"
-      disableGitFeatures = $false
-      disableDefaultFilter = $false
+      ],
+      "dest": "build/api",
+      "disableGitFeatures": true,
+      "disableDefaultFilter": false
     }
-  build = @{
-    content = @{
-        src = "build/api"
-        files = , "**.yml"
-        dest = "api"
+  ],
+  "build": {
+    "content": [
+      {
+        "src": "build/api",
+        "files": [ "**.yml" ],
+        "dest": "api"
       },
-      @{
-        src = "."
-        files = "toc.yml", "*.md"
+      {
+        "src": ".",
+        "files": [ "toc.yml", "*.md" ]
       }
-    overwrite = ,
-      @{
-        files = , "apidoc/**.md"
-        exclude = "obj/**", "html/**"
-      }
-    dest = "build/html"
-    globalMetadata = @{
-      _disableContribution = $true
-    }
-    template = , "default"
-    disableGitFeatures = $true
+    ],
+    "dest": "build/html",
+    "globalMetadata": {
+      "_disableContribution": true
+    },
+    "template": [ "default" ],
+    "disableGitFeatures": true
   }
 }
-convertTo-json -inputObject $docfxConfig -depth 10 | set-content -path docfx.json 
+"@
 
 # Run the documentation generator
 docfx docfx.json

--- a/.ldrelease/build-docs.ps1
+++ b/.ldrelease/build-docs.ps1
@@ -7,7 +7,7 @@ if (-not (get-Command docfx -errorAction silentlyContinue))
 $projectDir = $(get-location)
 $tempDir = "$HOME\temp"
 
-$projectName = dir "${env:LD_RELEASE_PROJECT_DIR}/src" | %{$_.Name}
+$projectName = dir "$projectDir/src" | %{$_.Name}
 
 $tempDocsDir = "$tempDir/build-docs"
 remove-item $tempDocsDir -recurse -force -errorAction ignore

--- a/.ldrelease/build-docs.ps1
+++ b/.ldrelease/build-docs.ps1
@@ -15,12 +15,11 @@ if ("$env:LD_RELEASE_DOCS_TITLE" -eq "") {
 $ErrorActionPreference = "Stop"
 set-strictmode -version latest
 
-# Import helper functions and set up paths (helpers.psm1 comes from Releaser's
-# built-in scripts)
+# Import helper functions and set up paths
 $projectDir = get-location
 $tempDir = "$HOME\temp"
 $scriptDir = split-path -parent $MyInvocation.MyCommand.Definition
-import-module "$scriptDir\circleci\template\helpers.psm1" -force
+import-module "$scriptDir\zip-helper.ps1" -force
 
 # Install DocFX
 if (-not (get-Command docfx -errorAction silentlyContinue))
@@ -100,7 +99,7 @@ docfx docfx.json
 
 # Make an archive of the output and store it as a single artifact. The
 # built-in CompressArchive command in PowerShell 5 produces archives that
-# aren't valid on other platforms, so we're using a helper from helpers.psm1
+# aren't valid on other platforms, so we're using the Zip helper from zip-helper.ps1
 Zip -sourcePath "$tempDocsDir/build/html" -zipFile "$projectDir/artifacts/docs.zip"
 
 set-location $projectDir

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -17,7 +17,6 @@ template:
   name: dotnet-windows
   env:
     LD_RELEASE_TEST_TARGET_FRAMEWORK: net461
-    LD_RELEASE_DOCS_TARGET_FRAMEWORK: net452
 
 documentation:
   githubPages: true

--- a/.ldrelease/zip-helper.ps1
+++ b/.ldrelease/zip-helper.ps1
@@ -1,0 +1,21 @@
+
+# see: https://stackoverflow.com/questions/27289115/system-io-compression-zipfile-net-4-5-output-zip-in-not-suitable-for-linux-mac
+class FixZipFilePathEncoding : System.Text.UTF8Encoding {
+    FixZipFilePathEncoding() : base($true) { }
+    [byte[]] GetBytes([string] $s)
+    {
+        $s = $s.Replace("\", "/");
+        return ([System.Text.UTF8Encoding]$this).GetBytes($s);
+    }
+}
+
+function Zip {
+    param(
+        [Parameter(Mandatory)][string]$sourcePath,
+        [Parameter(Mandatory)][string]$zipFile
+    )
+    [Reflection.Assembly]::LoadWithPartialName( "System.IO.Compression.FileSystem" ) | Out-Null
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($sourcePath, $zipFile, `
+        [System.IO.Compression.CompressionLevel]::Optimal, $false,
+        [FixZipFilePathEncoding]::new())
+}


### PR DESCRIPTION
This is a change to our release procedures that I'd like to integrate into our regular release tool for all of our .NET projects, and it'd be nice to use it for the upcoming LD .NET SDK 6.0 release, but it's easiest to test it on a single relatively independent project first.

We've been using Microsoft's obsolete Sandcastle Help File Builder tool to generate HTML documentation from doc comments. Besides being very old and unmaintained, it can only run in Windows, but for many years there was no real alternative (Doxygen is supposed to be compatible with C#, but I could never get it to work). However, in the last few years Microsoft has been improving its newer DocFX tool to the point where it seems usable for our purposes. DocFX has some idiosyncracies but it's maintained, and since it's a .NET Core app it can _theoretically_ run on Linux, which would be considerably more convenient for us.

The output of the tool looks pretty good - you can view an example [here](https://483-99271538-gh.circle-artifacts.com/0/artifacts/docs/index.html). The home page is very minimal, it would probably be better to just drop people directly into the API docs for the main mainspace but I haven't figured out if there's a way to do that.

Things I still need to figure out before we can use this more widely:

* So far I've been unable to run it on Linux - see [this issue](https://github.com/dotnet/docfx/issues/7347#issuecomment-833138151). The fact that they've tagged that issue as "v3" makes me think it might not get fixed in the current major version, so we may need to keep running it on a Windows CI host for releases. That's OK for now since we're using Windows for the rest of the release anyway, and it doesn't require nearly as much PowerShell scripting as the previous Sandcastle solution, but Linux would be simpler, especially now that .NET 5.0 will allow us to build all our code (even for .NET Framework) in a Linux container.
* I'm still a bit confused about how to integrate non-code-generated content into the docs. Specifically, C# doesn't have a standard way to document a _namespace_ (Sandcastle had a hack for this), and for our larger projects like the server-side .NET SDK it's desirable to have namespace summary pages that have some explanatory text, not just a list of classes. DocFX does have a way to add in Markdown files, but their documentation leaves something to be desired.