### PR TITLE
update LaunchDarkly.Logging dependency to latest patch

### DIFF
--- a/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
+++ b/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,2.0.0)" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,2.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
There is no functional difference between versions 1.0.0 and 1.0.1 of LaunchDarkly.Logging, but we want to be able to have consistent versions of transitive dependencies from all the packages used by the LaunchDarkly SDK— to minimize the need for binding redirects in .NET Framework, which is stricter about such things than .NET Core.