### PR TITLE
tests/comment edits for new HttpRequestModifier feature

### DIFF
--- a/src/LaunchDarkly.EventSource/ConfigurationBuilder.cs
+++ b/src/LaunchDarkly.EventSource/ConfigurationBuilder.cs
@@ -78,9 +78,10 @@ namespace LaunchDarkly.EventSource
             ResponseStartTimeout(responseStartTimeout);
 
         /// <summary>
-        /// Sets a delegate hook invoked before an HTTP request has been performed.
+        /// Sets a delegate hook invoked before an HTTP request is performed. This may be useful if you
+        /// want to modify some properties of the request that EventSource doesn't already have an option for.
         /// </summary>
-        /// <param name="httpRequestModifier">The hook delegate</param>
+        /// <param name="httpRequestModifier">code that will be called with the request before it is sent</param>
         /// <returns>the builder</returns>
         public ConfigurationBuilder HttpRequestModifier(Action<HttpRequestMessage> httpRequestModifier)
         {

--- a/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTest.cs
+++ b/test/LaunchDarkly.EventSource.Tests/ConfigurationBuilderTest.cs
@@ -301,5 +301,13 @@ namespace LaunchDarkly.EventSource.Tests
             var c = b.Build().RequestBodyFactory();
             Assert.IsType<StringContent>(c);
         }
+
+        [Fact]
+        public void BuilderSetsHttpRequestModifier()
+        {
+            Action<HttpRequestMessage> action = request => { };
+            var b = Configuration.Builder(uri).HttpRequestModifier(action);
+            Assert.Equal(action, b.Build().HttpRequestModifier);
+        }
     }
 }

--- a/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
+++ b/test/LaunchDarkly.EventSource.Tests/LaunchDarkly.EventSource.Tests.csproj
@@ -25,7 +25,6 @@
 
 	<ItemGroup>
     <ProjectReference Include="..\..\src\LaunchDarkly.EventSource\LaunchDarkly.EventSource.csproj" />
-    <ProjectReference Include="..\..\..\dotnet-test-helpers\src\LaunchDarkly.TestHelpers\LaunchDarkly.TestHelpers.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Just a few bits I wanted to round out before merging this externally contributed feature (see: https://github.com/launchdarkly/dotnet-eventsource/pull/85).