### PR TITLE
allow using LaunchDarkly.Logging 2.x

### DIFF
--- a/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
+++ b/src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,2.0.0)" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">


### PR DESCRIPTION
I had meant to do this as part of the platform compatibility updates. There are no API differences in LaunchDarkly.Logging between 1.x and 2.x, it was just a change in target frameworks, so either is acceptable. This can be a patch release of EventSource.