### PR TITLE
ci: switch from SLSA provenance to actions/attest with subject-path

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -4,11 +4,6 @@ inputs:
   dry_run:
     description: 'Is this a dry run. If so no package will be published.'
     required: true
-outputs:
-  hashes:
-    description: sha256sum hashes of built artifacts
-    value: ${{ steps.hash.outputs.hashes }}
-
 runs:
   using: composite
   steps:
@@ -32,13 +27,6 @@ runs:
           dotnet nuget push "${pkg}" --api-key ${{ env.NUGET_API_KEY }} --source https://www.nuget.org
           echo "published ${pkg}"
         done
-
-    - name: Hash nuget packages
-      id: hash
-      if: ${{ inputs.dry_run == 'false' }}
-      shell: bash
-      run: |
-        echo "hashes=$(sha256sum ./nupkgs/*.nupkg ./nupkgs/*.snupkg | base64 -w0)" >> "$GITHUB_OUTPUT"
 
     - name: Dry Run Publish
       if: ${{ inputs.dry_run == 'true' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Attest build provenance
-        if: ${{ inputs.dry_run == 'false' }}
+        if: ${{ format('{0}', inputs.dry_run) == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,14 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
+        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: true
 
   workflow_call:
     inputs:
@@ -22,6 +27,11 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
+      publish_release:
+        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   publish:
@@ -84,3 +94,19 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
+
+  publish-release:
+    needs: ['publish']
+    if: ${{ !inputs.dry_run && inputs.publish_release }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,9 @@ on:
         type: boolean
         required: true
       tag:
-        description: 'Tag of an existing draft release. For a dry run the value does not matter.'
+        description: 'Tag for provenance. For a dry run the value does not matter.'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: true
 
   workflow_call:
     inputs:
@@ -27,11 +22,6 @@ on:
         description: 'Tag for provenance'
         type: string
         required: true
-      publish_release:
-        description: 'Publish (un-draft) the release after all artifacts are uploaded?'
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   publish:
@@ -56,7 +46,6 @@ jobs:
             /production/common/releasing/digicert/code_signing_cert_sha1_hash = DIGICERT_CODE_SIGNING_CERT_SHA1_HASH,
             /production/common/releasing/nuget/api_key = NUGET_API_KEY'
           s3_path_pairs: 'launchdarkly-releaser/dotnet/LaunchDarkly.EventSource.snk = LaunchDarkly.EventSource.snk'
-
 
       - name: Build Release
         uses: ./.github/actions/release-build
@@ -94,19 +83,3 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-checksums: checksums.txt
-
-  publish-release:
-    needs: ['publish']
-    if: ${{ !inputs.dry_run && inputs.publish_release }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ inputs.tag }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,20 +7,12 @@ on:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
         required: true
-      tag:
-        description: 'Tag for provenance. For a dry run the value does not matter.'
-        type: string
-        required: true
 
   workflow_call:
     inputs:
       dry_run:
         description: 'Is this a dry run. If so no package will be published.'
         type: boolean
-        required: true
-      tag:
-        description: 'Tag for provenance'
-        type: string
         required: true
 
 jobs:
@@ -72,7 +64,7 @@ jobs:
           dry_run: ${{ inputs.dry_run }}
 
       - name: Attest build provenance
-        if: ${{ !inputs.dry_run }}
+        if: ${{ inputs.dry_run == 'false' }}
         uses: actions/attest@v4
         with:
           subject-path: 'nupkgs/*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       id-token: write # Needed if using OIDC to get release secrets.
       contents: write # Contents and pull-requests are for release-please to make releases.
       pull-requests: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v4
@@ -71,16 +72,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-  provenance:
-    permissions:
-      actions: read
-      id-token: write
-      contents: write
-    if: ${{ inputs.dry_run  == 'false' }}
-    needs: ['publish']
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
-    with:
-      base64-subjects: "${{ needs.publish.outputs.hashes }}"
-      upload-assets: true
-      upload-tag-name: ${{ inputs.tag }}
-      provenance-name: ${{ format('LaunchDarkly.EventSource-{0}_provenance.intoto.jsonl', inputs.tag) }}
+      - name: Generate checksums file
+        if: ${{ !inputs.dry_run }}
+        env:
+          HASHES: ${{ steps.publish.outputs.hashes }}
+        run: |
+          echo "$HASHES" | base64 -d > checksums.txt
+
+      - name: Attest build provenance
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest@v4
+        with:
+          subject-checksums: checksums.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,15 +71,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           dry_run: ${{ inputs.dry_run }}
 
-      - name: Generate checksums file
-        if: ${{ !inputs.dry_run }}
-        env:
-          HASHES: ${{ steps.publish.outputs.hashes }}
-        run: |
-          echo "$HASHES" | base64 -d > checksums.txt
-
       - name: Attest build provenance
         if: ${{ !inputs.dry_run }}
         uses: actions/attest@v4
         with:
-          subject-checksums: checksums.txt
+          subject-path: 'nupkgs/*'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,4 +34,3 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
-      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,6 @@ jobs:
   release-please:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Needed if using OIDC to get release secrets.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,14 +23,57 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           target-branch: main
 
+  create-tag:
+    needs: ['release-please']
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
   ci:
     needs: ['release-please']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/ci.yml
+
   publish:
-    needs: ['release-please', 'ci']
+    needs: ['release-please', 'ci', 'create-tag']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: ['release-please', 'publish']
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,57 +23,15 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           target-branch: main
 
-  create-tag:
-    needs: ['release-please']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Create release tag
-        env:
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
-            echo "Tag ${TAG_NAME} already exists, skipping creation."
-          else
-            echo "Creating tag ${TAG_NAME}."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag "${TAG_NAME}"
-            git push origin "${TAG_NAME}"
-          fi
-
   ci:
     needs: ['release-please']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/ci.yml
 
   publish:
-    needs: ['release-please', 'ci', 'create-tag']
+    needs: ['release-please', 'ci']
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:
       dry_run: false
       tag: ${{ needs.release-please.outputs.tag_name }}
-
-  publish-release:
-    needs: ['release-please', 'publish']
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-        run: >
-          gh release edit "$TAG_NAME"
-          --repo ${{ github.repository }}
-          --draft=false

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,49 @@
+## Verifying SDK build provenance with GitHub artifact attestations
+
+LaunchDarkly uses [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published SDK packages.
+
+LaunchDarkly publishes provenance about our SDK package builds using [GitHub's `actions/attest` action](https://github.com/actions/attest). These attestations are stored in GitHub's attestation API and can be verified using the [GitHub CLI](https://cli.github.com/).
+
+To verify build provenance attestations, we recommend using the [GitHub CLI `attestation verify` command](https://cli.github.com/manual/gh_attestation_verify). Example usage for verifying SDK packages is included below:
+
+<!-- x-release-please-start-version -->
+```
+# Set the version of the SDK to verify
+SDK_VERSION=5.3.0
+```
+<!-- x-release-please-end -->
+
+```
+# Download the nupkg from NuGet
+$ nuget install LaunchDarkly.EventSource -Version $SDK_VERSION -OutputDirectory ./packages
+
+# Verify provenance using the GitHub CLI
+$ gh attestation verify ./packages/LaunchDarkly.EventSource.${SDK_VERSION}/LaunchDarkly.EventSource.${SDK_VERSION}.nupkg --owner launchdarkly
+```
+
+Below is a sample of expected output.
+
+```
+Loaded digest sha256:... for file://LaunchDarkly.EventSource.5.3.0.nupkg
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/launchdarkly
+- Subject Alternative Name must match regex: (?i)^https://github.com/launchdarkly/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... launchdarkly/dotnet-eventsource
+  - Build workflow:. .github/workflows/release-please.yml
+  - Signer repo:.... launchdarkly/dotnet-eventsource
+  - Signer workflow: .github/workflows/release-please.yml
+```
+
+For more information, see [GitHub's documentation on verifying artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+**Note:** These instructions do not apply when building our SDKs from source.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Public key token is 18e8c36453e3060f
 
 We encourage pull requests and other contributions from the community. Check out our [contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute to this project.
 
+## Verifying build provenance with the SLSA framework
+
+LaunchDarkly uses the [SLSA framework](https://slsa.dev/spec/v1.0/about) (Supply-chain Levels for Software Artifacts) to help developers make their supply chain more secure by ensuring the authenticity and build integrity of our published packages. To learn more, see the [provenance guide](PROVENANCE.md).
+
 ## About LaunchDarkly
 
 * LaunchDarkly is a continuous delivery platform that provides feature flags as a service and allows developers to iterate quickly and safely. We allow you to easily flag your features and manage them from the LaunchDarkly dashboard.  With LaunchDarkly, you can:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "bootstrap-sha": "42cd339937a4affdbe94ab0d49694a86eb85c75f",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
-      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj"
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "bootstrap-sha": "42cd339937a4affdbe94ab0d49694a86eb85c75f",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
-      "draft": true,
       "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "bootstrap-sha": "42cd339937a4affdbe94ab0d49694a86eb85c75f",
       "include-v-in-tag": false,
       "include-component-in-tag": false,
+      "draft": true,
       "extra-files": [
         "src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj"
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false,
       "draft": true,
+      "force-tag-creation": true,
       "extra-files": [
         "src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj"
       ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false,
       "extra-files": [
-        "src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj"
+        "src/LaunchDarkly.EventSource/LaunchDarkly.EventSource.csproj",
+        "PROVENANCE.md"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Adapts the release workflow for GitHub's immutable releases feature. Since this repo only uses attestation (no binary/artifact uploads to the release), draft releases are **not** needed — `actions/attest@v4` stores attestations via GitHub's attestation API, not as release assets.

**Changes across 6 files:**

1. **`.github/actions/publish/action.yml`** — Removed the `hashes` output and "Hash nuget packages" step that base64-encoded SHA256 checksums. These existed to feed the old SLSA generator's `base64-subjects` input and are no longer needed since attestation now uses `subject-path` to reference artifacts directly on disk.

2. **`.github/workflows/publish.yml`** — Replaced the separate `provenance` job (SLSA `generator_generic_slsa3` reusable workflow with `upload-assets: true`) with an inline `actions/attest@v4` step in the `publish` job using `subject-path: 'nupkgs/*'`. Added `attestations: write` permission. Removed the unused `tag` input from both `workflow_dispatch` and `workflow_call` triggers. This eliminates the base64 encode/decode round-trip, the checksums file generation, and the `.intoto.jsonl` release asset upload entirely.

3. **`.github/workflows/release-please.yml`** — Removed `tag: ${{ needs.release-please.outputs.tag_name }}` from the publish workflow call and the `tag_name` output from the `release-please` job (both are dead code after the `tag` input removal).

4. **`release-please-config.json`** — Added `PROVENANCE.md` to `extra-files` so release-please keeps the version placeholder in sync on each release.

5. **`PROVENANCE.md`** *(new)* — Added provenance verification guide with `gh attestation verify` instructions and sample output, using the `x-release-please-start-version` marker to keep the version in sync with releases.

6. **`README.md`** — Added a "Verifying build provenance with the SLSA framework" section linking to the new `PROVENANCE.md`.

### Why `subject-path` instead of `subject-checksums`?

The previous intermediate revision used `subject-checksums` with a base64 decode step to convert the composite action's hash output into a checksums file. This was redundant — the `.nupkg` and `.snupkg` files are already on disk in `./nupkgs/` within the same job, so `subject-path: 'nupkgs/*'` lets `actions/attest@v4` compute checksums directly. This removes all hash-related plumbing from both the composite action and the workflow.

### Why no draft releases?

The old SLSA generator uploaded `.intoto.jsonl` provenance files as release assets (via `upload-assets: true`), which would fail under immutable releases if the release was already published. The new `actions/attest@v4` stores attestations in GitHub's attestation API instead, so the release can be published directly by release-please without needing a draft→publish flow.

### Why `format('{0}', inputs.dry_run)` for the condition?

GitHub Actions `workflow_dispatch` delivers boolean inputs as strings (`'false'`), while `workflow_call` delivers them as actual booleans (`false`). A plain `== 'false'` comparison silently fails when receiving a real boolean. Using `format('{0}', inputs.dry_run)` coerces either type to a string before comparison, ensuring the guard works for both trigger sources.

### Updates since last revision

- Reverted the split release-please pattern (two-pass `skip-github-pull-request` / `skip-github-release`) that was briefly added. This pattern is only needed for repos that upload artifacts to releases (which require draft releases). Since this repo is attestation-only, the standard single-pass release-please is correct.

## Review & Testing Checklist for Human

- [ ] Verify the `subject-path: 'nupkgs/*'` glob matches the output of `dotnet pack --output nupkgs` in the composite action (should capture both `.nupkg` and `.snupkg` files). If the directory is empty or missing at attest time (e.g. during a dry run), confirm the `format('{0}', inputs.dry_run) == 'false'` guard prevents the attest step from running.
- [ ] Confirm `attestations: write` permission on the `publish` job is sufficient for `actions/attest@v4` (the old SLSA generator ran as a separate job with `actions: read`, `id-token: write`, and `contents: write`).
- [ ] Validate end-to-end by running a dry-run dispatch of `publish.yml` (should skip attestation) and then a real release to confirm the attest step succeeds and no `.intoto.jsonl` asset is expected by downstream consumers.
- [ ] Verify the `PROVENANCE.md` version placeholder (`5.3.0`) is updated by release-please via the `x-release-please-start-version` / `x-release-please-end` markers on the next release.

### Notes
- The `format('{0}', inputs.dry_run) == 'false'` condition coerces the boolean/string input to a consistent string before comparison, per [GitHub Actions expressions docs](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions).
- `release-please.yml` still references `releases_created` (plural) — existing output names are preserved.
- No changes to `release-please-config.json` remain beyond the `PROVENANCE.md` extra-file addition (the previously-added `force-tag-creation` was reverted as unnecessary for non-draft repos).
- The removed `provenance` job previously generated a named `.intoto.jsonl` file uploaded as a release asset. Confirm no tooling or verification process depends on that specific asset being present on the GitHub release.
- The `PROVENANCE.md` sample output is templated from the real `gh attestation verify` output format — repo name and workflow references are specific to this repository.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84