### PR TITLE
ci: add permissions to caller jobs and upgrade release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,7 @@ jobs:
     needs: ['release-please']
     permissions:
       id-token: write
+      contents: read
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/ci.yml
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -24,11 +24,18 @@ jobs:
 
   ci:
     needs: ['release-please']
+    permissions:
+      id-token: write
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/ci.yml
 
   publish:
     needs: ['release-please', 'ci']
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      attestations: write
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     uses: ./.github/workflows/publish.yml
     with:


### PR DESCRIPTION
## Summary
Fixes Release Please `startup_failure` by adding explicit `permissions` to the `ci` and `publish` caller jobs. Also upgrades release-please-action from v4 to v5.

## Review & Testing Checklist for Human
- [ ] Verify the release-please workflow runs without startup_failure on next push to main
- [ ] Confirm publish.yml permissions match what's declared on the caller
- [ ] Verify the `ci` caller job's `contents: read` is sufficient for `actions/checkout`

### Notes
Same fix pattern as dotnet-core PR #241. Caller jobs need explicit permissions because the reusable workflows declare permissions that exceed the restricted org defaults. Added `contents: read` to the `ci` caller per Bugbot feedback — when `permissions` is declared, unmentioned permissions default to `none`.

Link to Devin session: https://app.devin.ai/sessions/54e32482848742c19ebf9c374efdc833
Requested by: @kinyoklion